### PR TITLE
add Client-Side monitoring.

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,72 @@
+// Copyright 2016 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+// gRPC Prometheus monitoring interceptors for client-side gRPC.
+
+package grpc_prometheus
+
+import (
+	"io"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+// UnaryClientInterceptor is a gRPC client-side interceptor that provides Prometheus monitoring for Unary RPCs.
+func UnaryClientInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	monitor := newClientReporter(Unary, method)
+	monitor.SentMessage()
+	err := invoker(ctx, method, req, reply, cc, opts...)
+	if err != nil {
+		monitor.ReceivedMessage()
+	}
+	monitor.Handled(grpc.Code(err))
+	return err
+}
+
+// StreamServerInterceptor is a gRPC client-side interceptor that provides Prometheus monitoring for Streaming RPCs.
+func StreamClientInterceptor(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	monitor := newClientReporter(clientStreamType(desc), method)
+	clientStream, err := streamer(ctx, desc, cc, method, opts...)
+	if err != nil {
+		monitor.Handled(grpc.Code(err))
+		return nil, err
+	}
+	return &monitoredClientStream{clientStream, monitor}, nil
+}
+
+func clientStreamType(desc *grpc.StreamDesc) grpcType {
+	if desc.ClientStreams && !desc.ServerStreams {
+		return ClientStream
+	} else if !desc.ClientStreams && desc.ServerStreams {
+		return ServerStream
+	}
+	return BidiStream
+}
+
+// monitoredClientStream wraps grpc.ClientStream allowing each Sent/Recv of message to increment counters.
+type monitoredClientStream struct {
+	grpc.ClientStream
+	monitor *clientReporter
+}
+
+func (s *monitoredClientStream) SendMsg(m interface{}) error {
+	err := s.ClientStream.SendMsg(m)
+	if err == nil {
+		s.monitor.SentMessage()
+	}
+	return err
+}
+
+func (s *monitoredClientStream) RecvMsg(m interface{}) error {
+	err := s.ClientStream.RecvMsg(m)
+	if err == nil {
+		s.monitor.ReceivedMessage()
+	} else if err == io.EOF {
+		s.monitor.Handled(codes.OK)
+	} else {
+		s.monitor.Handled(grpc.Code(err))
+	}
+	return err
+}

--- a/client_reporter.go
+++ b/client_reporter.go
@@ -1,0 +1,111 @@
+// Copyright 2016 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package grpc_prometheus
+
+import (
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	prom "github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	clientStartedCounter = prom.NewCounterVec(
+		prom.CounterOpts{
+			Namespace: "grpc",
+			Subsystem: "client",
+			Name:      "started_total",
+			Help:      "Total number of RPCs started on the client.",
+		}, []string{"grpc_type", "grpc_service", "grpc_method"})
+
+	clientHandledCounter = prom.NewCounterVec(
+		prom.CounterOpts{
+			Namespace: "grpc",
+			Subsystem: "client",
+			Name:      "handled_total",
+			Help:      "Total number of RPCs completed by the client, regardless of success or failure.",
+		}, []string{"grpc_type", "grpc_service", "grpc_method", "grpc_code"})
+
+	clientStreamMsgReceived = prom.NewCounterVec(
+		prom.CounterOpts{
+			Namespace: "grpc",
+			Subsystem: "client",
+			Name:      "msg_received_total",
+			Help:      "Total number of RPC stream messages received by the client.",
+		}, []string{"grpc_type", "grpc_service", "grpc_method"})
+
+	clientStreamMsgSent = prom.NewCounterVec(
+		prom.CounterOpts{
+			Namespace: "grpc",
+			Subsystem: "client",
+			Name:      "msg_sent_total",
+			Help:      "Total number of gRPC stream messages sent by the client.",
+		}, []string{"grpc_type", "grpc_service", "grpc_method"})
+
+	clientHandledHistogramEnabled = false
+	clientHandledHistogramOpts    = prom.HistogramOpts{
+		Namespace: "grpc",
+		Subsystem: "client",
+		Name:      "handling_seconds",
+		Help:      "Histogram of response latency (seconds) of the gRPC until it is finished by the application.",
+		Buckets:   prom.DefBuckets,
+	}
+	clientHandledHistogram *prom.HistogramVec
+)
+
+func init() {
+	prom.MustRegister(clientStartedCounter)
+	prom.MustRegister(clientHandledCounter)
+	prom.MustRegister(clientStreamMsgReceived)
+	prom.MustRegister(clientStreamMsgSent)
+}
+
+// EnableClientHandlingTimeHistogram turns on recording of handling time of RPCs.
+// Histogram metrics can be very expensive for Prometheus to retain and query.
+func EnableClientHandlingTimeHistogram(opts ...HistogramOption) {
+	for _, o := range opts {
+		o(&clientHandledHistogramOpts)
+	}
+	if !clientHandledHistogramEnabled {
+		clientHandledHistogram = prom.NewHistogramVec(
+			clientHandledHistogramOpts,
+			[]string{"grpc_type", "grpc_service", "grpc_method"},
+		)
+		prom.Register(clientHandledHistogram)
+	}
+	clientHandledHistogramEnabled = true
+}
+
+type clientReporter struct {
+	rpcType     grpcType
+	serviceName string
+	methodName  string
+	startTime   time.Time
+}
+
+func newClientReporter(rpcType grpcType, fullMethod string) *clientReporter {
+	r := &clientReporter{rpcType: rpcType}
+	if clientHandledHistogramEnabled {
+		r.startTime = time.Now()
+	}
+	r.serviceName, r.methodName = splitMethodName(fullMethod)
+	clientStartedCounter.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Inc()
+	return r
+}
+
+func (r *clientReporter) ReceivedMessage() {
+	clientStreamMsgReceived.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Inc()
+}
+
+func (r *clientReporter) SentMessage() {
+	clientStreamMsgSent.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Inc()
+}
+
+func (r *clientReporter) Handled(code codes.Code) {
+	clientHandledCounter.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName, code.String()).Inc()
+	if clientHandledHistogramEnabled {
+		clientHandledHistogram.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Observe(time.Since(r.startTime).Seconds())
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -47,7 +47,6 @@ func (s *ClientInterceptorTestSuite) SetupSuite() {
 	pb_testproto.RegisterTestServiceServer(s.server, &testService{t: s.T()})
 
 	go func() {
-		s.T().Logf("starting grpc.Server at: %v", s.serverListener.Addr().String())
 		s.server.Serve(s.serverListener)
 	}()
 

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,213 @@
+// Copyright 2016 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package grpc_prometheus
+
+import (
+	"net"
+	"testing"
+
+	"time"
+
+	"io"
+
+	pb_testproto "github.com/grpc-ecosystem/go-grpc-prometheus/examples/testproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+func TestClientInterceptorSuite(t *testing.T) {
+	suite.Run(t, &ClientInterceptorTestSuite{})
+}
+
+type ClientInterceptorTestSuite struct {
+	suite.Suite
+
+	serverListener net.Listener
+	server         *grpc.Server
+	clientConn     *grpc.ClientConn
+	testClient     pb_testproto.TestServiceClient
+	ctx            context.Context
+}
+
+func (s *ClientInterceptorTestSuite) SetupSuite() {
+	var err error
+
+	EnableClientHandlingTimeHistogram()
+
+	s.serverListener, err = net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(s.T(), err, "must be able to allocate a port for serverListener")
+
+	// This is the point where we hook up the interceptor
+	s.server = grpc.NewServer()
+	pb_testproto.RegisterTestServiceServer(s.server, &testService{t: s.T()})
+
+	go func() {
+		s.T().Logf("starting grpc.Server at: %v", s.serverListener.Addr().String())
+		s.server.Serve(s.serverListener)
+	}()
+
+	s.clientConn, err = grpc.Dial(
+		s.serverListener.Addr().String(),
+		grpc.WithInsecure(),
+		grpc.WithBlock(),
+		grpc.WithUnaryInterceptor(UnaryClientInterceptor),
+		grpc.WithStreamInterceptor(StreamClientInterceptor),
+		grpc.WithTimeout(2*time.Second))
+	require.NoError(s.T(), err, "must not error on client Dial")
+	s.testClient = pb_testproto.NewTestServiceClient(s.clientConn)
+}
+
+func (s *ClientInterceptorTestSuite) SetupTest() {
+	// Make all RPC calls last at most 2 sec, meaning all async issues or deadlock will not kill tests.
+	s.ctx, _ = context.WithTimeout(context.TODO(), 2*time.Second)
+}
+
+func (s *ClientInterceptorTestSuite) TearDownSuite() {
+	if s.serverListener != nil {
+		s.server.Stop()
+		s.T().Logf("stopped grpc.Server at: %v", s.serverListener.Addr().String())
+		s.serverListener.Close()
+
+	}
+	if s.clientConn != nil {
+		s.clientConn.Close()
+	}
+}
+
+func (s *ClientInterceptorTestSuite) TestUnaryIncrementsStarted() {
+	var before int
+	var after int
+
+	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_started_total", "PingEmpty", "unary")
+	s.testClient.PingEmpty(s.ctx, &pb_testproto.Empty{})
+	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_started_total", "PingEmpty", "unary")
+	assert.EqualValues(s.T(), before+1, after, "grpc_client_started_total should be incremented for PingEmpty")
+
+	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_started_total", "PingError", "unary")
+	s.testClient.PingError(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.Unavailable)})
+	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_started_total", "PingError", "unary")
+	assert.EqualValues(s.T(), before+1, after, "grpc_client_started_total should be incremented for PingError")
+}
+
+func (s *ClientInterceptorTestSuite) TestUnaryIncrementsHandled() {
+	var before int
+	var after int
+
+	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingEmpty", "unary", "OK")
+	s.testClient.PingEmpty(s.ctx, &pb_testproto.Empty{}) // should return with code=OK
+	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingEmpty", "unary", "OK")
+	assert.EqualValues(s.T(), before+1, after, "grpc_client_handled_count should be incremented for PingEmpty")
+
+	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingError", "unary", "FailedPrecondition")
+	s.testClient.PingError(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
+	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingError", "unary", "FailedPrecondition")
+	assert.EqualValues(s.T(), before+1, after, "grpc_client_handled_total should be incremented for PingError")
+}
+
+func (s *ClientInterceptorTestSuite) TestUnaryIncrementsHistograms() {
+	var before int
+	var after int
+
+	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingEmpty", "unary")
+	s.testClient.PingEmpty(s.ctx, &pb_testproto.Empty{}) // should return with code=OK
+	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingEmpty", "unary")
+	assert.EqualValues(s.T(), before+1, after, "grpc_client_handled_count should be incremented for PingEmpty")
+
+	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingError", "unary")
+	s.testClient.PingError(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
+	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingError", "unary")
+	assert.EqualValues(s.T(), before+1, after, "grpc_client_handling_seconds_count should be incremented for PingError")
+}
+
+func (s *ClientInterceptorTestSuite) TestStreamingIncrementsStarted() {
+	var before int
+	var after int
+
+	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_started_total", "PingList", "server_stream")
+	s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{})
+	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_started_total", "PingList", "server_stream")
+	assert.EqualValues(s.T(), before+1, after, "grpc_client_started_total should be incremented for PingList")
+}
+
+func (s *ClientInterceptorTestSuite) TestStreamingIncrementsHistograms() {
+	var before int
+	var after int
+
+	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingList", "server_stream")
+	ss, _ := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{}) // should return with code=OK
+	// Do a read, just for kicks.
+	for {
+		_, err := ss.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(s.T(), err, "reading pingList shouldn't fail")
+	}
+	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingList", "server_stream")
+	assert.EqualValues(s.T(), before+1, after, "grpc_client_handling_seconds_count should be incremented for PingList OK")
+
+	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingList", "server_stream")
+	ss, err := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
+	require.NoError(s.T(), err, "PingList must not fail immedietely")
+	// Do a read, just to progate errors.
+	_, err = ss.Recv()
+	require.Equal(s.T(), codes.FailedPrecondition, grpc.Code(err), "Recv must return FailedPrecondition, otherwise the test is wrong")
+
+	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingList", "server_stream")
+	assert.EqualValues(s.T(), before+1, after, "grpc_client_handling_seconds_count should be incremented for PingList FailedPrecondition")
+}
+
+func (s *ClientInterceptorTestSuite) TestStreamingIncrementsHandled() {
+	var before int
+	var after int
+
+	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingList", "server_stream", "OK")
+	ss, _ := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{}) // should return with code=OK
+	// Do a read, just for kicks.
+	for {
+		_, err := ss.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(s.T(), err, "reading pingList shouldn't fail")
+	}
+	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingList", "server_stream", "OK")
+	assert.EqualValues(s.T(), before+1, after, "grpc_client_handled_total should be incremented for PingList OK")
+
+	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingList", "server_stream", "FailedPrecondition")
+	ss, err := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
+	require.NoError(s.T(), err, "PingList must not fail immedietely")
+	// Do a read, just to progate errors.
+	_, err = ss.Recv()
+	require.Equal(s.T(), codes.FailedPrecondition, grpc.Code(err), "Recv must return FailedPrecondition, otherwise the test is wrong")
+
+	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingList", "server_stream", "FailedPrecondition")
+	assert.EqualValues(s.T(), before+1, after, "grpc_client_handled_total should be incremented for PingList FailedPrecondition")
+}
+
+func (s *ClientInterceptorTestSuite) TestStreamingIncrementsMessageCounts() {
+	beforeRecv := sumCountersForMetricAndLabels(s.T(), "grpc_client_msg_received_total", "PingList", "server_stream")
+	beforeSent := sumCountersForMetricAndLabels(s.T(), "grpc_client_msg_sent_total", "PingList", "server_stream")
+	ss, _ := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{}) // should return with code=OK
+	// Do a read, just for kicks.
+	count := 0
+	for {
+		_, err := ss.Recv()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(s.T(), err, "reading pingList shouldn't fail")
+		count += 1
+	}
+	require.EqualValues(s.T(), countListResponses, count, "Number of received msg on the wire must match")
+	afterSent := sumCountersForMetricAndLabels(s.T(), "grpc_client_msg_sent_total", "PingList", "server_stream")
+	afterRecv := sumCountersForMetricAndLabels(s.T(), "grpc_client_msg_received_total", "PingList", "server_stream")
+
+	assert.EqualValues(s.T(), beforeSent+1, afterSent, "grpc_client_msg_sent_total should be incremented 20 times for PingList")
+	assert.EqualValues(s.T(), beforeRecv+countListResponses, afterRecv, "grpc_client_msg_sent_total should be incremented ones for PingList ")
+}

--- a/server_reporter.go
+++ b/server_reporter.go
@@ -79,7 +79,7 @@ func WithHistogramBuckets(buckets []float64) HistogramOption {
 	return func(o *prom.HistogramOpts) { o.Buckets = buckets }
 }
 
-// EnableHandlingTimeHistogram turns on recording of handling time of RPCs.
+// EnableHandlingTimeHistogram turns on recording of handling time of RPCs for server-side interceptors.
 // Histogram metrics can be very expensive for Prometheus to retain and query.
 func EnableHandlingTimeHistogram(opts ...HistogramOption) {
 	for _, o := range opts {

--- a/server_test.go
+++ b/server_test.go
@@ -59,7 +59,6 @@ func (s *ServerInterceptorTestSuite) SetupSuite() {
 	pb_testproto.RegisterTestServiceServer(s.server, &testService{t: s.T()})
 
 	go func() {
-		s.T().Logf("starting grpc.Server at: %v", s.serverListener.Addr().String())
 		s.server.Serve(s.serverListener)
 	}()
 


### PR DESCRIPTION
This PR adds support for client-side monitoring of gRPC Go.

@iamqizhao the client side interceptor APIs seem pretty good, thanks! :)