### PR TITLE
Decouple registration from grpc.Server implementation

### DIFF
--- a/server.go
+++ b/server.go
@@ -10,10 +10,15 @@ import (
 	"google.golang.org/grpc"
 )
 
+// Server defines the interface that is required for grpc_prometheus to Register.
+type Server interface {
+	GetServiceInfo() map[string]grpc.ServiceInfo
+}
+
 // Register takes a gRPC server and pre-initializes all counters to 0.
 // This allows for easier monitoring in Prometheus (no missing metrics), and
 // should be called *after* all services have been registered with the server.
-func Register(server *grpc.Server) {
+func Register(server Server) {
 	RegisterServiceInfo(server.GetServiceInfo())
 }
 

--- a/server.go
+++ b/server.go
@@ -10,11 +10,17 @@ import (
 	"google.golang.org/grpc"
 )
 
-// PreregisterServices takes a gRPC server and pre-initializes all counters to 0.
-// This allows for easier monitoring in Prometheus (no missing metrics), and should be called *after* all services have
-// been registered with the server.
+// Register takes a gRPC server and pre-initializes all counters to 0.
+// This allows for easier monitoring in Prometheus (no missing metrics), and
+// should be called *after* all services have been registered with the server.
 func Register(server *grpc.Server) {
-	serviceInfo := server.GetServiceInfo()
+	RegisterServiceInfo(server.GetServiceInfo())
+}
+
+// RegisterServiceInfo takes a map of gRPC ServiceInfo objects and per-initializes all counters to 0.
+// This allows for easier monitoring in Prometheus (no missing metrics), and
+// should be called *after* all services have been registered with the server.
+func RegisterServiceInfo(serviceInfo map[string]grpc.ServiceInfo) {
 	for serviceName, info := range serviceInfo {
 		for _, mInfo := range info.Methods {
 			preRegisterMethod(serviceName, &mInfo)


### PR DESCRIPTION
Hi,

I was hoping this library could decouple the registration for monitoring from the specific implementation of `*grpc.Server` that it's currently tied to. From what I can tell all that grpc prometheus cares about for registration is that it has a bunch of service info objects that describe what it can monitor. So it seems like we can expose direct access to that via `RegisterServiceInfo` so that someone could register arbitrary services. In addition, we can define what is important for a `server` in `Register`, namely that it can get said service info, via an interface so that current code works but that function is no longer tied explicitly to grpc's particular server implementation. In my particular use case I have a queue consumer that consumes the RPCs defined by the protobufs but my concrete type obviously isn't `*grpc.Server`, even though I can expose `GetServiceInfo()` to describe what services I consume.

A couple notes:

1. I could see a signature of `RegisterServiceInfo (info grpc.ServiceInfo)` that pre registers the methods for that service only and `Register` (or an external callee) could do the iteration themselves.
2. I wasn't sure the best way to add tests as the current ones have global test setup that call `Register` and then one test that checks metrics registered so it wasn't apparent how to structure single calls to `RegisterServiceInfo` without introducing ordering dependencies in the existing tests.