### PR TITLE
update README with non-deprecated promhttp Handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import "github.com/grpc-ecosystem/go-grpc-prometheus"
     // After all your registrations, make sure all of the Prometheus metrics are initialized.
     grpc_prometheus.Register(myServer)
     // Register Prometheus metrics handler.    
-    http.Handle("/metrics", prometheus.Handler())
+    http.Handle("/metrics", promhttp.Handler())
 ...
 ```
 


### PR DESCRIPTION
The `http.Handler()` is deprecated per [golang client http.go comment](https://github.com/prometheus/client_golang/blob/master/prometheus/http.go#L63-L66):
```
// Deprecated: Please note the issues described in the doc comment of
// InstrumentHandler. You might want to consider using promhttp.Handler instead
// (which is not instrumented, but can be instrumented with the tooling provided
// in package promhttp).
```
Update README to recommend non-deprecated [Handler from promhttp](https://github.com/prometheus/client_golang/blob/master/prometheus/promhttp/http.go#L77).