### PR TITLE
ClientMetrics registration & prometheus.Collector implementation

### DIFF
--- a/client_metrics.go
+++ b/client_metrics.go
@@ -61,6 +61,32 @@ func NewClientMetrics() *ClientMetrics {
 	}
 }
 
+// Describe sends the super-set of all possible descriptors of metrics
+// collected by this Collector to the provided channel and returns once
+// the last descriptor has been sent.
+func (m *ClientMetrics) Describe(ch chan<- *prom.Desc) {
+	m.clientStartedCounter.Describe(ch)
+	m.clientHandledCounter.Describe(ch)
+	m.clientStreamMsgReceived.Describe(ch)
+	m.clientStreamMsgSent.Describe(ch)
+	if m.clientHandledHistogramEnabled {
+		m.clientHandledHistogram.Describe(ch)
+	}
+}
+
+// Collect is called by the Prometheus registry when collecting
+// metrics. The implementation sends each collected metric via the
+// provided channel and returns once the last metric has been sent.
+func (m *ClientMetrics) Collect(ch chan<- prom.Metric) {
+	m.clientStartedCounter.Collect(ch)
+	m.clientHandledCounter.Collect(ch)
+	m.clientStreamMsgReceived.Collect(ch)
+	m.clientStreamMsgSent.Collect(ch)
+	if m.clientHandledHistogramEnabled {
+		m.clientHandledHistogram.Collect(ch)
+	}
+}
+
 // EnableClientHandlingTimeHistogram turns on recording of handling time of RPCs.
 // Histogram metrics can be very expensive for Prometheus to retain and query.
 func (m *ClientMetrics) EnableClientHandlingTimeHistogram(opts ...HistogramOption) {

--- a/client_test.go
+++ b/client_test.go
@@ -12,12 +12,18 @@ import (
 	"io"
 
 	pb_testproto "github.com/grpc-ecosystem/go-grpc-prometheus/examples/testproto"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+)
+
+var (
+	// client metrics must satisfy the Collector interface
+	_ prometheus.Collector = NewClientMetrics()
 )
 
 func TestClientInterceptorSuite(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -24,6 +24,11 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
+var (
+	// server metrics must satisfy the Collector interface
+	_ prometheus.Collector = NewServerMetrics()
+)
+
 const (
 	pingDefaultValue   = "I like kittens."
 	countListResponses = 20


### PR DESCRIPTION
Hey,

It seems the ClientMetrics was missing a way to register the metrics with Prometheus. ServerMetrics has Register and MustRegister methods for this. In this PR, I've implemented the prometheus.Collector interface on both ServerMetrics and ClientMetrics so using the code feels a bit more like using a normal Prometheus metric. I've retained the old methods to keep backwards compatibility but changed them so they use the normal prometheus.Registerer methods.  