### PR TITLE
add variadic counterOpts funcs to server and client metrics constructor

### DIFF
--- a/client_metrics.go
+++ b/client_metrics.go
@@ -25,31 +25,32 @@ type ClientMetrics struct {
 // ClientMetrics when not using the default Prometheus metrics registry, for
 // example when wanting to control which metrics are added to a registry as
 // opposed to automatically adding metrics via init functions.
-func NewClientMetrics() *ClientMetrics {
+func NewClientMetrics(counterOpts ...CounterOption) *ClientMetrics {
+	opts := counterOptions(counterOpts)
 	return &ClientMetrics{
 		clientStartedCounter: prom.NewCounterVec(
-			prom.CounterOpts{
+			opts.apply(prom.CounterOpts{
 				Name: "grpc_client_started_total",
 				Help: "Total number of RPCs started on the client.",
-			}, []string{"grpc_type", "grpc_service", "grpc_method"}),
+			}), []string{"grpc_type", "grpc_service", "grpc_method"}),
 
 		clientHandledCounter: prom.NewCounterVec(
-			prom.CounterOpts{
+			opts.apply(prom.CounterOpts{
 				Name: "grpc_client_handled_total",
 				Help: "Total number of RPCs completed by the client, regardless of success or failure.",
-			}, []string{"grpc_type", "grpc_service", "grpc_method", "grpc_code"}),
+			}), []string{"grpc_type", "grpc_service", "grpc_method", "grpc_code"}),
 
 		clientStreamMsgReceived: prom.NewCounterVec(
-			prom.CounterOpts{
+			opts.apply(prom.CounterOpts{
 				Name: "grpc_client_msg_received_total",
 				Help: "Total number of RPC stream messages received by the client.",
-			}, []string{"grpc_type", "grpc_service", "grpc_method"}),
+			}), []string{"grpc_type", "grpc_service", "grpc_method"}),
 
 		clientStreamMsgSent: prom.NewCounterVec(
-			prom.CounterOpts{
+			opts.apply(prom.CounterOpts{
 				Name: "grpc_client_msg_sent_total",
 				Help: "Total number of gRPC stream messages sent by the client.",
-			}, []string{"grpc_type", "grpc_service", "grpc_method"}),
+			}), []string{"grpc_type", "grpc_service", "grpc_method"}),
 
 		clientHandledHistogramEnabled: false,
 		clientHandledHistogramOpts: prom.HistogramOpts{

--- a/metric_options.go
+++ b/metric_options.go
@@ -32,3 +32,28 @@ func WithNamespace(ns string) CounterOption {
 		o.Namespace = ns
 	}
 }
+
+type HistogramOption func(*prom.HistogramOpts)
+
+// WithHistogramBuckets allows you to specify custom bucket ranges for histograms if EnableHandlingTimeHistogram is on.
+func WithHistogramBuckets(buckets []float64) HistogramOption {
+	return func(o *prom.HistogramOpts) { o.Buckets = buckets }
+}
+
+func WithHistogramConstLabels(labels prom.Labels) HistogramOption {
+	return func(o *prom.HistogramOpts) {
+		o.ConstLabels = labels
+	}
+}
+
+func WithHistogramSubsystem(subsystem string) HistogramOption {
+	return func(o *prom.HistogramOpts) {
+		o.Subsystem = subsystem
+	}
+}
+
+func WithHistogramNamespace(ns string) HistogramOption {
+	return func(o *prom.HistogramOpts) {
+		o.Namespace = ns
+	}
+}

--- a/metric_options.go
+++ b/metric_options.go
@@ -21,18 +21,6 @@ func WithConstLabels(labels prom.Labels) CounterOption {
 	}
 }
 
-func WithSubsystem(subsystem string) CounterOption {
-	return func(o *prom.CounterOpts) {
-		o.Subsystem = subsystem
-	}
-}
-
-func WithNamespace(ns string) CounterOption {
-	return func(o *prom.CounterOpts) {
-		o.Namespace = ns
-	}
-}
-
 type HistogramOption func(*prom.HistogramOpts)
 
 // WithHistogramBuckets allows you to specify custom bucket ranges for histograms if EnableHandlingTimeHistogram is on.
@@ -43,17 +31,5 @@ func WithHistogramBuckets(buckets []float64) HistogramOption {
 func WithHistogramConstLabels(labels prom.Labels) HistogramOption {
 	return func(o *prom.HistogramOpts) {
 		o.ConstLabels = labels
-	}
-}
-
-func WithHistogramSubsystem(subsystem string) HistogramOption {
-	return func(o *prom.HistogramOpts) {
-		o.Subsystem = subsystem
-	}
-}
-
-func WithHistogramNamespace(ns string) HistogramOption {
-	return func(o *prom.HistogramOpts) {
-		o.Namespace = ns
 	}
 }

--- a/metric_options.go
+++ b/metric_options.go
@@ -1,0 +1,34 @@
+package grpc_prometheus
+
+import (
+	prom "github.com/prometheus/client_golang/prometheus"
+)
+
+type CounterOption func(opts *prom.CounterOpts)
+
+type counterOptions []CounterOption
+
+func (co counterOptions) apply(o prom.CounterOpts) prom.CounterOpts {
+	for _, f := range co {
+		f(&o)
+	}
+	return o
+}
+
+func WithConstLabels(labels prom.Labels) CounterOption {
+	return func(o *prom.CounterOpts) {
+		o.ConstLabels = labels
+	}
+}
+
+func WithSubsystem(subsystem string) CounterOption {
+	return func(o *prom.CounterOpts) {
+		o.Subsystem = subsystem
+	}
+}
+
+func WithNamespace(ns string) CounterOption {
+	return func(o *prom.CounterOpts) {
+		o.Namespace = ns
+	}
+}

--- a/server_metrics.go
+++ b/server_metrics.go
@@ -22,28 +22,29 @@ type ServerMetrics struct {
 // ServerMetrics when not using the default Prometheus metrics registry, for
 // example when wanting to control which metrics are added to a registry as
 // opposed to automatically adding metrics via init functions.
-func NewServerMetrics() *ServerMetrics {
+func NewServerMetrics(counterOpts ...CounterOption) *ServerMetrics {
+	opts := counterOptions(counterOpts)
 	return &ServerMetrics{
 		serverStartedCounter: prom.NewCounterVec(
-			prom.CounterOpts{
+			opts.apply(prom.CounterOpts{
 				Name: "grpc_server_started_total",
 				Help: "Total number of RPCs started on the server.",
-			}, []string{"grpc_type", "grpc_service", "grpc_method"}),
+			}), []string{"grpc_type", "grpc_service", "grpc_method"}),
 		serverHandledCounter: prom.NewCounterVec(
-			prom.CounterOpts{
+			opts.apply(prom.CounterOpts{
 				Name: "grpc_server_handled_total",
 				Help: "Total number of RPCs completed on the server, regardless of success or failure.",
-			}, []string{"grpc_type", "grpc_service", "grpc_method", "grpc_code"}),
+			}), []string{"grpc_type", "grpc_service", "grpc_method", "grpc_code"}),
 		serverStreamMsgReceived: prom.NewCounterVec(
-			prom.CounterOpts{
+			opts.apply(prom.CounterOpts{
 				Name: "grpc_server_msg_received_total",
 				Help: "Total number of RPC stream messages received on the server.",
-			}, []string{"grpc_type", "grpc_service", "grpc_method"}),
+			}), []string{"grpc_type", "grpc_service", "grpc_method"}),
 		serverStreamMsgSent: prom.NewCounterVec(
-			prom.CounterOpts{
+			opts.apply(prom.CounterOpts{
 				Name: "grpc_server_msg_sent_total",
 				Help: "Total number of gRPC stream messages sent by the server.",
-			}, []string{"grpc_type", "grpc_service", "grpc_method"}),
+			}), []string{"grpc_type", "grpc_service", "grpc_method"}),
 		serverHandledHistogramEnabled: false,
 		serverHandledHistogramOpts: prom.HistogramOpts{
 			Name:    "grpc_server_handling_seconds",

--- a/server_metrics.go
+++ b/server_metrics.go
@@ -62,6 +62,24 @@ func WithHistogramBuckets(buckets []float64) HistogramOption {
 	return func(o *prom.HistogramOpts) { o.Buckets = buckets }
 }
 
+func WithHistogramConstLabels(labels prom.Labels) HistogramOption {
+	return func(o *prom.HistogramOpts) {
+		o.ConstLabels = labels
+	}
+}
+
+func WithHistogramSubsystem(subsystem string) HistogramOption {
+	return func(o *prom.HistogramOpts) {
+		o.Subsystem = subsystem
+	}
+}
+
+func WithHistogramNamespace(ns string) HistogramOption {
+	return func(o *prom.HistogramOpts) {
+		o.Namespace = ns
+	}
+}
+
 // EnableHandlingTimeHistogram enables histograms being registered when
 // registering the ServerMetrics on a Prometheus registry. Histograms can be
 // expensive on Prometheus servers. It takes options to configure histogram

--- a/server_metrics.go
+++ b/server_metrics.go
@@ -55,31 +55,6 @@ func NewServerMetrics(counterOpts ...CounterOption) *ServerMetrics {
 	}
 }
 
-type HistogramOption func(*prom.HistogramOpts)
-
-// WithHistogramBuckets allows you to specify custom bucket ranges for histograms if EnableHandlingTimeHistogram is on.
-func WithHistogramBuckets(buckets []float64) HistogramOption {
-	return func(o *prom.HistogramOpts) { o.Buckets = buckets }
-}
-
-func WithHistogramConstLabels(labels prom.Labels) HistogramOption {
-	return func(o *prom.HistogramOpts) {
-		o.ConstLabels = labels
-	}
-}
-
-func WithHistogramSubsystem(subsystem string) HistogramOption {
-	return func(o *prom.HistogramOpts) {
-		o.Subsystem = subsystem
-	}
-}
-
-func WithHistogramNamespace(ns string) HistogramOption {
-	return func(o *prom.HistogramOpts) {
-		o.Namespace = ns
-	}
-}
-
 // EnableHandlingTimeHistogram enables histograms being registered when
 // registering the ServerMetrics on a Prometheus registry. Histograms can be
 // expensive on Prometheus servers. It takes options to configure histogram


### PR DESCRIPTION
we have the use case that we need to add const label pairs to the metrics. We are exposing a gRPC service w/ and w/o TLS and we want to partition the metrics on a label "schema". So I added a variadic option func to the metric constructors. As the options don't have many fields, I added option funcs for Namespace, Subsystem and Namespace as well.

If it makes sense to you, I would add some documentation for the option functions.
