### PR TITLE
Added Summary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,33 @@ grpc_server_handling_seconds_sum{grpc_code="OK",grpc_method="PingList",grpc_serv
 grpc_server_handling_seconds_count{grpc_code="OK",grpc_method="PingList",grpc_service="mwitkow.testproto.TestService",grpc_type="server_stream"} 1
 ```
 
+## Summaries
+[Summaries](https://prometheus.io/docs/concepts/metric_types/#summary) are another way to measure latency distribution.
+
+In contrast to Histogram, Summary calculates configurable quantiles over a sliding time window. Use Summaries if you need an accurate quantile, no matter what the range and distribution of the values is.
+
+To enable them please call the following in your server initialization code:
+
+```jsoniq
+grpc_prometheus.EnableHandlingTimeSummary()
+```
+
+After the call completes, it's handling time will be recorded in a [Prometheus summary](https://prometheus.io/docs/concepts/metric_types/#summary)
+variable `grpc_server_handling_seconds_summary`. It contains three sub-metrics:
+
+ * `grpc_server_handling_seconds_summary_count` - the count of all completed RPCs by status and method
+ * `grpc_server_handling_seconds_summary_sum` - cumulative time of RPCs by status and method, useful for calculating average handling times
+ * `grpc_server_handling_seconds_summary` - contains [quantiles](https://prometheus.io/docs/practices/histograms/#quantiles) of RPCs handling-time by status and method
+
+The counter values will look like as follows:
+
+```jsoniq
+grpc_server_handling_seconds_summary{grpc_code="OK",grpc_method="PingList",grpc_service="mwitkow.testproto.TestService",grpc_type="server_stream",quantile="0.5"} 0.0003866430000000001
+grpc_server_handling_seconds_summary{grpc_code="OK",grpc_method="PingList",grpc_service="mwitkow.testproto.TestService",grpc_type="server_stream",quantile="0.9"} 0.0003866430000000001
+grpc_server_handling_seconds_summary{grpc_code="OK",grpc_method="PingList",grpc_service="mwitkow.testproto.TestService",grpc_type="server_stream",quantile="0.99"} 0.0003866430000000001
+grpc_server_handling_seconds_summary_sum{grpc_code="OK",grpc_method="PingList",grpc_service="mwitkow.testproto.TestService",grpc_type="server_stream"} 0.0003866430000000001
+grpc_server_handling_seconds_summary_count{grpc_code="OK",grpc_method="PingList",grpc_service="mwitkow.testproto.TestService",grpc_type="server_stream"} 1
+```
 
 ## Useful query examples
 

--- a/client.go
+++ b/client.go
@@ -37,3 +37,12 @@ func EnableClientHandlingTimeHistogram(opts ...HistogramOption) {
 	DefaultClientMetrics.EnableClientHandlingTimeHistogram(opts...)
 	prom.Register(DefaultClientMetrics.clientHandledHistogram)
 }
+
+// EnableClientHandlingTimeSummary turns on recording of handling time of
+// RPCs. Summary metrics can be very expensive for Prometheus to retain and
+// collect. This function acts on the DefaultClientMetrics variable and the
+// default Prometheus metrics registry.
+func EnableClientHandlingTimeSummary(opts ...SummaryOption) {
+	DefaultClientMetrics.EnableClientHandlingTimeSummary(opts...)
+	prom.Register(DefaultClientMetrics.clientHandledSummary)
+}

--- a/client_reporter.go
+++ b/client_reporter.go
@@ -22,7 +22,7 @@ func newClientReporter(m *ClientMetrics, rpcType grpcType, fullMethod string) *c
 		metrics: m,
 		rpcType: rpcType,
 	}
-	if r.metrics.clientHandledHistogramEnabled {
+	if r.metrics.clientHandledHistogramEnabled || r.metrics.clientHandledSummaryEnabled {
 		r.startTime = time.Now()
 	}
 	r.serviceName, r.methodName = splitMethodName(fullMethod)
@@ -42,5 +42,8 @@ func (r *clientReporter) Handled(code codes.Code) {
 	r.metrics.clientHandledCounter.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName, code.String()).Inc()
 	if r.metrics.clientHandledHistogramEnabled {
 		r.metrics.clientHandledHistogram.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Observe(time.Since(r.startTime).Seconds())
+	}
+	if r.metrics.clientHandledSummaryEnabled {
+		r.metrics.clientHandledSummary.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Observe(time.Since(r.startTime).Seconds())
 	}
 }

--- a/server.go
+++ b/server.go
@@ -46,3 +46,12 @@ func EnableHandlingTimeHistogram(opts ...HistogramOption) {
 	DefaultServerMetrics.EnableHandlingTimeHistogram(opts...)
 	prom.Register(DefaultServerMetrics.serverHandledHistogram)
 }
+
+// EnableHandlingTimeSummary turns on recording of handling time
+// of RPCs. Histogram metrics can be very expensive for Prometheus
+// to retain and collect. This function acts on the DefaultServerMetrics
+// variable and the default Prometheus metrics registry.
+func EnableHandlingTimeSummary(opts ...SummaryOption) {
+	DefaultServerMetrics.EnableHandlingTimeSummary(opts...)
+	prom.Register(DefaultServerMetrics.serverHandledSummary)
+}

--- a/server_reporter.go
+++ b/server_reporter.go
@@ -22,7 +22,7 @@ func newServerReporter(m *ServerMetrics, rpcType grpcType, fullMethod string) *s
 		metrics: m,
 		rpcType: rpcType,
 	}
-	if r.metrics.serverHandledHistogramEnabled {
+	if r.metrics.serverHandledHistogramEnabled || r.metrics.serverHandledSummaryEnabled {
 		r.startTime = time.Now()
 	}
 	r.serviceName, r.methodName = splitMethodName(fullMethod)
@@ -42,5 +42,8 @@ func (r *serverReporter) Handled(code codes.Code) {
 	r.metrics.serverHandledCounter.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName, code.String()).Inc()
 	if r.metrics.serverHandledHistogramEnabled {
 		r.metrics.serverHandledHistogram.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Observe(time.Since(r.startTime).Seconds())
+	}
+	if r.metrics.serverHandledSummaryEnabled {
+		r.metrics.serverHandledSummary.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Observe(time.Since(r.startTime).Seconds())
 	}
 }


### PR DESCRIPTION
I've tried adding histograms to [Helm](https://github.com/kubernetes/helm) in https://github.com/kubernetes/helm/pull/3036 but quickly found out that histograms are useless with small amount of requests and hugely varying response times (like when you do `helm install` of some arbitrary chart which could have large docker images or long-running init-containers/readiness probes).

Prometheus' summaries are better fit for this case, so I've added the support for it.