### PR TITLE
Some cleanups for megacheck warnings

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -161,7 +162,8 @@ func (s *ClientInterceptorTestSuite) TestStreamingIncrementsHistograms() {
 	require.NoError(s.T(), err, "PingList must not fail immediately")
 	// Do a read, just to progate errors.
 	_, err = ss.Recv()
-	require.Equal(s.T(), codes.FailedPrecondition, grpc.Code(err), "Recv must return FailedPrecondition, otherwise the test is wrong")
+	st, _ := status.FromError(err)
+	require.Equal(s.T(), codes.FailedPrecondition, st.Code(), "Recv must return FailedPrecondition, otherwise the test is wrong")
 
 	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingList", "server_stream")
 	assert.EqualValues(s.T(), before+1, after, "grpc_client_handling_seconds_count should be incremented for PingList FailedPrecondition")
@@ -189,7 +191,8 @@ func (s *ClientInterceptorTestSuite) TestStreamingIncrementsHandled() {
 	require.NoError(s.T(), err, "PingList must not fail immediately")
 	// Do a read, just to progate errors.
 	_, err = ss.Recv()
-	require.Equal(s.T(), codes.FailedPrecondition, grpc.Code(err), "Recv must return FailedPrecondition, otherwise the test is wrong")
+	st, _ := status.FromError(err)
+	require.Equal(s.T(), codes.FailedPrecondition, st.Code(), "Recv must return FailedPrecondition, otherwise the test is wrong")
 
 	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingList", "server_stream", "FailedPrecondition")
 	assert.EqualValues(s.T(), before+1, after, "grpc_client_handled_total should be incremented for PingList FailedPrecondition")

--- a/server_test.go
+++ b/server_test.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -297,12 +298,12 @@ func (s *testService) Ping(ctx context.Context, ping *pb_testproto.PingRequest) 
 
 func (s *testService) PingError(ctx context.Context, ping *pb_testproto.PingRequest) (*pb_testproto.Empty, error) {
 	code := codes.Code(ping.ErrorCodeReturned)
-	return nil, grpc.Errorf(code, "Userspace error.")
+	return nil, status.Errorf(code, "Userspace error.")
 }
 
 func (s *testService) PingList(ping *pb_testproto.PingRequest, stream pb_testproto.TestService_PingListServer) error {
 	if ping.ErrorCodeReturned != 0 {
-		return grpc.Errorf(codes.Code(ping.ErrorCodeReturned), "foobar")
+		return status.Errorf(codes.Code(ping.ErrorCodeReturned), "foobar")
 	}
 	// Send user trailers and headers.
 	for i := 0; i < countListResponses; i++ {

--- a/util.go
+++ b/util.go
@@ -37,13 +37,13 @@ func splitMethodName(fullMethodName string) (string, string) {
 }
 
 func typeFromMethodInfo(mInfo *grpc.MethodInfo) grpcType {
-	if mInfo.IsClientStream == false && mInfo.IsServerStream == false {
+	if !mInfo.IsClientStream && !mInfo.IsServerStream {
 		return Unary
 	}
-	if mInfo.IsClientStream == true && mInfo.IsServerStream == false {
+	if mInfo.IsClientStream && !mInfo.IsServerStream {
 		return ClientStream
 	}
-	if mInfo.IsClientStream == false && mInfo.IsServerStream == true {
+	if !mInfo.IsClientStream && mInfo.IsServerStream {
 		return ServerStream
 	}
 	return BidiStream


### PR DESCRIPTION
Please review (esp the `grpc.Code()` commit).

See the individual commit messages for details.

I've only tested with `go test` so far.