### PR TITLE
Modification: Add the monitor of prometheus for gRPC client

### DIFF
--- a/examples/grpc-server-with-prometheus/client/client.go
+++ b/examples/grpc-server-with-prometheus/client/client.go
@@ -18,17 +18,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-var (
-	// Create some standard client metrics
-	grpcMetrics = grpc_prometheus.NewClientMetrics()
-)
-
 func main() {
 	// Create a metrics registry.
 	reg := prometheus.NewRegistry()
+	// Create some standard client metrics.
+	grpcMetrics := grpc_prometheus.NewClientMetrics()
 	// Register client metrics to registry.
 	reg.MustRegister(grpcMetrics)
-
 	// Create a insecure gRPC channel to communicate with the server.
 	conn, err := grpc.Dial(
 		fmt.Sprintf("localhost:%v", 9093),
@@ -62,7 +58,6 @@ func main() {
 			if err != nil {
 				log.Fatal(err)
 			}
-			// Sleep 3 seconds.
 			time.Sleep(3 * time.Second)
 		}
 	}()

--- a/examples/grpc-server-with-prometheus/client/client.go
+++ b/examples/grpc-server-with-prometheus/client/client.go
@@ -56,7 +56,9 @@ func main() {
 			// Call “SayHello” method and wait for response from gRPC Server.
 			_, err := client.SayHello(context.Background(), &pb.HelloRequest{Name: "Test"})
 			if err != nil {
-				log.Fatal(err)
+				log.Printf("Calling the SayHello method unsuccessfully. ErrorInfo: %+v", err)
+				log.Printf("You should to stop the process")
+				return
 			}
 			time.Sleep(3 * time.Second)
 		}

--- a/examples/grpc-server-with-prometheus/client/client.go
+++ b/examples/grpc-server-with-prometheus/client/client.go
@@ -1,14 +1,38 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	pb "github.com/grpc-ecosystem/go-grpc-prometheus/examples/grpc-server-with-prometheus/protobuf"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
+
+var (
+	// Create a metrics registry.
+	reg = prometheus.NewRegistry()
+
+	// Create a customized counter metric.
+	customizedCounterMetric = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "demo_client_say_hello_method_call_count",
+		Help: "Total number of RPCs called on the client.",
+	}, []string{"name"})
+)
+
+func init() {
+	// Register customized metrics to registry.
+	reg.MustRegister(customizedCounterMetric)
+	customizedCounterMetric.WithLabelValues("Test")
+}
 
 func main() {
 	// Create a insecure gRPC channel to communicate with the server.
@@ -22,13 +46,37 @@ func main() {
 
 	defer conn.Close()
 
+	// Create a HTTP server for prometheus.
+	httpServer := &http.Server{Handler: promhttp.HandlerFor(reg, promhttp.HandlerOpts{}), Addr: fmt.Sprintf("0.0.0.0:%d", 9094)}
+
+	// Start your http server for prometheus.
+	go func() {
+		if err := httpServer.ListenAndServe(); err != nil {
+			log.Fatal("Unable to start a http server.")
+		}
+	}()
+
 	// Create a gRPC server client.
 	client := pb.NewDemoServiceClient(conn)
-	// Call “SayHello” method and wait for response from gRPC Server.
-	resp, err := client.SayHello(context.Background(), &pb.HelloRequest{Name: "Test"})
-	if err != nil {
-		log.Fatal(err)
+	fmt.Println("Start to call the method called SayHello every 3 seconds")
+	go func() {
+		for {
+			// Call “SayHello” method and wait for response from gRPC Server.
+			_, err := client.SayHello(context.Background(), &pb.HelloRequest{Name: "Test"})
+			if err != nil {
+				log.Fatal(err)
+			}
+			// Increase the count of calling of SayHello
+			customizedCounterMetric.WithLabelValues("Test").Inc()
+			// Sleep 3 seconds.
+			time.Sleep(3 * time.Second)
+		}
+	}()
+	scanner := bufio.NewScanner(os.Stdin)
+	fmt.Println("You can press n or N to stop the process of client")
+	for scanner.Scan() {
+		if strings.ToLower(scanner.Text()) == "n" {
+			os.Exit(0)
+		}
 	}
-
-	fmt.Println(resp)
 }

--- a/examples/grpc-server-with-prometheus/prometheus/prometheus.yaml
+++ b/examples/grpc-server-with-prometheus/prometheus/prometheus.yaml
@@ -25,6 +25,10 @@ scrape_configs:
   #     - targets: ['localhost:9090']
 
   - job_name: 'grpcserver'
-    scrape_interval: 2s
+    scrape_interval: 1s
     static_configs:
       - targets: ['localhost:9092']
+  - job_name: 'grpcclient'
+    scrape_interval: 1s
+    static_configs:
+      - targets: ['localhost:9094']


### PR DESCRIPTION
#### Reason
The example of the gRPC client always lacks the monitor of Prometheus.
#### Modification

1. Add the monitor for the gRPC client

