### PR TITLE
promgrpc merge - change 1

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,35 +5,31 @@
 
 package grpc_prometheus
 
-import (
-	prom "github.com/prometheus/client_golang/prometheus"
-)
-
 var (
-	// DefaultClientMetrics is the default instance of ClientMetrics. It is
-	// intended to be used in conjunction the default Prometheus metrics
-	// registry.
-	DefaultClientMetrics = NewClientMetrics()
-
-	// UnaryClientInterceptor is a gRPC client-side interceptor that provides Prometheus monitoring for Unary RPCs.
-	UnaryClientInterceptor = DefaultClientMetrics.UnaryClientInterceptor()
-
-	// StreamClientInterceptor is a gRPC client-side interceptor that provides Prometheus monitoring for Streaming RPCs.
-	StreamClientInterceptor = DefaultClientMetrics.StreamClientInterceptor()
+//// DefaultClientMetrics is the default instance of ClientMetrics. It is
+//// intended to be used in conjunction the default Prometheus monitor
+//// registry.
+//DefaultClientMetrics = NewClientMetrics()
+//
+//// UnaryInterceptor is a gRPC client-side interceptor that provides Prometheus monitoring for Unary RPCs.
+//UnaryClientInterceptor = DefaultClientMetrics.UnaryInterceptor()
+//
+//// StreamInterceptor is a gRPC client-side interceptor that provides Prometheus monitoring for Streaming RPCs.
+//StreamClientInterceptor = DefaultClientMetrics.StreamInterceptor()
 )
 
 func init() {
-	prom.MustRegister(DefaultClientMetrics.clientStartedCounter)
-	prom.MustRegister(DefaultClientMetrics.clientHandledCounter)
-	prom.MustRegister(DefaultClientMetrics.clientStreamMsgReceived)
-	prom.MustRegister(DefaultClientMetrics.clientStreamMsgSent)
+	//prom.MustRegister(DefaultClientMetrics)
+	//prom.MustRegister(DefaultClientMetrics.clientHandledCounter)
+	//prom.MustRegister(DefaultClientMetrics.clientStreamMsgReceived)
+	//prom.MustRegister(DefaultClientMetrics.clientStreamMsgSent)
 }
 
 // EnableClientHandlingTimeHistogram turns on recording of handling time of
-// RPCs. Histogram metrics can be very expensive for Prometheus to retain and
+// RPCs. Histogram monitor can be very expensive for Prometheus to retain and
 // query. This function acts on the DefaultClientMetrics variable and the
-// default Prometheus metrics registry.
-func EnableClientHandlingTimeHistogram(opts ...HistogramOption) {
-	DefaultClientMetrics.EnableClientHandlingTimeHistogram(opts...)
-	prom.Register(DefaultClientMetrics.clientHandledHistogram)
-}
+// default Prometheus monitor registry.
+//func EnableClientHandlingTimeHistogram(opts ...HistogramCollectorOption) {
+//DefaultClientMetrics.EnableClientHandlingTimeHistogram(opts...)
+//prom.Register(DefaultClientMetrics.clientHandledHistogram)
+//}

--- a/client_metrics.go
+++ b/client_metrics.go
@@ -10,126 +10,57 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// ClientMetrics represents a collection of metrics to be registered on a
-// Prometheus metrics registry for a gRPC client.
+// ClientMetrics represents a collection of monitor to be registered on a
+// Prometheus monitor registry for a gRPC client.
 type ClientMetrics struct {
-	clientStartedCounter          *prom.CounterVec
-	clientHandledCounter          *prom.CounterVec
-	clientStreamMsgReceived       *prom.CounterVec
-	clientStreamMsgSent           *prom.CounterVec
-	clientHandledHistogramEnabled bool
-	clientHandledHistogramOpts    prom.HistogramOpts
-	clientHandledHistogram        *prom.HistogramVec
+	*clientMonitor
 }
 
 // NewClientMetrics returns a ClientMetrics object. Use a new instance of
-// ClientMetrics when not using the default Prometheus metrics registry, for
-// example when wanting to control which metrics are added to a registry as
-// opposed to automatically adding metrics via init functions.
-func NewClientMetrics(counterOpts ...CounterOption) *ClientMetrics {
-	opts := counterOptions(counterOpts)
+// ClientMetrics when not using the default Prometheus monitor registry, for
+// example when wanting to control which monitor are added to a registry as
+// opposed to automatically adding monitor via init functions.
+func NewClientMetrics(counterOpts ...CollectorOption) *ClientMetrics {
+	opts := counterOptions(counterOpts).apply(prom.Opts{
+		Namespace: namespace,
+		Subsystem: "client",
+	})
+
 	return &ClientMetrics{
-		clientStartedCounter: prom.NewCounterVec(
-			opts.apply(prom.CounterOpts{
-				Name: "grpc_client_started_total",
-				Help: "Total number of RPCs started on the client.",
-			}), []string{"grpc_type", "grpc_service", "grpc_method"}),
-
-		clientHandledCounter: prom.NewCounterVec(
-			opts.apply(prom.CounterOpts{
-				Name: "grpc_client_handled_total",
-				Help: "Total number of RPCs completed by the client, regardless of success or failure.",
-			}), []string{"grpc_type", "grpc_service", "grpc_method", "grpc_code"}),
-
-		clientStreamMsgReceived: prom.NewCounterVec(
-			opts.apply(prom.CounterOpts{
-				Name: "grpc_client_msg_received_total",
-				Help: "Total number of RPC stream messages received by the client.",
-			}), []string{"grpc_type", "grpc_service", "grpc_method"}),
-
-		clientStreamMsgSent: prom.NewCounterVec(
-			opts.apply(prom.CounterOpts{
-				Name: "grpc_client_msg_sent_total",
-				Help: "Total number of gRPC stream messages sent by the client.",
-			}), []string{"grpc_type", "grpc_service", "grpc_method"}),
-
-		clientHandledHistogramEnabled: false,
-		clientHandledHistogramOpts: prom.HistogramOpts{
-			Name:    "grpc_client_handling_seconds",
-			Help:    "Histogram of response latency (seconds) of the gRPC until it is finished by the application.",
-			Buckets: prom.DefBuckets,
-		},
-		clientHandledHistogram: nil,
+		clientMonitor: initClientMonitor(opts),
 	}
 }
 
-// Describe sends the super-set of all possible descriptors of metrics
-// collected by this Collector to the provided channel and returns once
-// the last descriptor has been sent.
-func (m *ClientMetrics) Describe(ch chan<- *prom.Desc) {
-	m.clientStartedCounter.Describe(ch)
-	m.clientHandledCounter.Describe(ch)
-	m.clientStreamMsgReceived.Describe(ch)
-	m.clientStreamMsgSent.Describe(ch)
-	if m.clientHandledHistogramEnabled {
-		m.clientHandledHistogram.Describe(ch)
-	}
-}
-
-// Collect is called by the Prometheus registry when collecting
-// metrics. The implementation sends each collected metric via the
-// provided channel and returns once the last metric has been sent.
-func (m *ClientMetrics) Collect(ch chan<- prom.Metric) {
-	m.clientStartedCounter.Collect(ch)
-	m.clientHandledCounter.Collect(ch)
-	m.clientStreamMsgReceived.Collect(ch)
-	m.clientStreamMsgSent.Collect(ch)
-	if m.clientHandledHistogramEnabled {
-		m.clientHandledHistogram.Collect(ch)
-	}
-}
-
-// EnableClientHandlingTimeHistogram turns on recording of handling time of RPCs.
-// Histogram metrics can be very expensive for Prometheus to retain and query.
-func (m *ClientMetrics) EnableClientHandlingTimeHistogram(opts ...HistogramOption) {
-	for _, o := range opts {
-		o(&m.clientHandledHistogramOpts)
-	}
-	if !m.clientHandledHistogramEnabled {
-		m.clientHandledHistogram = prom.NewHistogramVec(
-			m.clientHandledHistogramOpts,
-			[]string{"grpc_type", "grpc_service", "grpc_method"},
-		)
-	}
-	m.clientHandledHistogramEnabled = true
-}
-
-// UnaryClientInterceptor is a gRPC client-side interceptor that provides Prometheus monitoring for Unary RPCs.
-func (m *ClientMetrics) UnaryClientInterceptor() func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+// UnaryInterceptor is a gRPC client-side interceptor that provides Prometheus monitoring for Unary RPCs.
+func (m *ClientMetrics) UnaryInterceptor() grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		monitor := newClientReporter(m, Unary, method)
-		monitor.SentMessage()
+		rep := newClientReporter(m.clientMonitor, Unary, method)
+		rep.outgoingRequest()
+		rep.outgoingMessage() // TODO: necessary?
+
 		err := invoker(ctx, method, req, reply, cc, opts...)
 		if err != nil {
-			monitor.ReceivedMessage()
+			rep.incomingMessage()
 		}
 		st, _ := status.FromError(err)
-		monitor.Handled(st.Code())
+		rep.incomingResponse(st.Code())
 		return err
 	}
 }
 
-// StreamClientInterceptor is a gRPC client-side interceptor that provides Prometheus monitoring for Streaming RPCs.
-func (m *ClientMetrics) StreamClientInterceptor() func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+// StreamInterceptor is a gRPC client-side interceptor that provides Prometheus monitoring for Streaming RPCs.
+func (m *ClientMetrics) StreamInterceptor() grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-		monitor := newClientReporter(m, clientStreamType(desc), method)
+		rep := newClientReporter(m.clientMonitor, clientStreamType(desc), method)
+		rep.outgoingRequest()
+
 		clientStream, err := streamer(ctx, desc, cc, method, opts...)
 		if err != nil {
 			st, _ := status.FromError(err)
-			monitor.Handled(st.Code())
+			rep.incomingResponse(st.Code())
 			return nil, err
 		}
-		return &monitoredClientStream{clientStream, monitor}, nil
+		return &monitoredClientStream{clientStream, rep}, nil
 	}
 }
 
@@ -151,7 +82,7 @@ type monitoredClientStream struct {
 func (s *monitoredClientStream) SendMsg(m interface{}) error {
 	err := s.ClientStream.SendMsg(m)
 	if err == nil {
-		s.monitor.SentMessage()
+		s.monitor.outgoingMessage()
 	}
 	return err
 }
@@ -159,12 +90,12 @@ func (s *monitoredClientStream) SendMsg(m interface{}) error {
 func (s *monitoredClientStream) RecvMsg(m interface{}) error {
 	err := s.ClientStream.RecvMsg(m)
 	if err == nil {
-		s.monitor.ReceivedMessage()
+		s.monitor.incomingMessage()
 	} else if err == io.EOF {
-		s.monitor.Handled(codes.OK)
+		s.monitor.incomingResponse(codes.OK)
 	} else {
 		st, _ := status.FromError(err)
-		s.monitor.Handled(st.Code())
+		s.monitor.incomingResponse(st.Code())
 	}
 	return err
 }

--- a/client_reporter.go
+++ b/client_reporter.go
@@ -6,41 +6,49 @@ package grpc_prometheus
 import (
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc/codes"
 )
 
 type clientReporter struct {
-	metrics     *ClientMetrics
+	monitor     *clientMonitor
 	rpcType     grpcType
 	serviceName string
 	methodName  string
 	startTime   time.Time
+	labels      prometheus.Labels
 }
 
-func newClientReporter(m *ClientMetrics, rpcType grpcType, fullMethod string) *clientReporter {
-	r := &clientReporter{
-		metrics: m,
-		rpcType: rpcType,
+func newClientReporter(m *clientMonitor, rpcType grpcType, fullMethod string) *clientReporter {
+	serviceName, methodName := splitMethodName(fullMethod)
+	return &clientReporter{
+		monitor:   m,
+		startTime: time.Now(),
+		labels: prometheus.Labels{
+			labelService: serviceName,
+			labelMethod:  methodName,
+			labelType:    string(rpcType),
+		},
 	}
-	if r.metrics.clientHandledHistogramEnabled {
-		r.startTime = time.Now()
-	}
-	r.serviceName, r.methodName = splitMethodName(fullMethod)
-	r.metrics.clientStartedCounter.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Inc()
-	return r
 }
 
-func (r *clientReporter) ReceivedMessage() {
-	r.metrics.clientStreamMsgReceived.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Inc()
+func (r *clientReporter) outgoingRequest() {
+	r.monitor.requestsTotal.With(r.labels).Inc()
 }
 
-func (r *clientReporter) SentMessage() {
-	r.metrics.clientStreamMsgSent.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Inc()
+func (r *clientReporter) outgoingMessage() {
+	r.monitor.messagesSent.With(r.labels).Inc()
 }
 
-func (r *clientReporter) Handled(code codes.Code) {
-	r.metrics.clientHandledCounter.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName, code.String()).Inc()
-	if r.metrics.clientHandledHistogramEnabled {
-		r.metrics.clientHandledHistogram.WithLabelValues(string(r.rpcType), r.serviceName, r.methodName).Observe(time.Since(r.startTime).Seconds())
+func (r *clientReporter) incomingMessage() {
+	r.monitor.messagesReceived.With(r.labels).Inc()
+}
+
+func (r *clientReporter) incomingResponse(code codes.Code) {
+	r.labels[labelCode] = code.String()
+	r.monitor.responsesTotal.With(r.labels).Inc()
+	r.monitor.requestDuration.With(r.labels).Observe(time.Since(r.startTime).Seconds())
+	if code != codes.OK {
+		r.monitor.errors.With(r.labels).Inc()
 	}
 }

--- a/examples/grpc-server-with-prometheus/client/client.go
+++ b/examples/grpc-server-with-prometheus/client/client.go
@@ -9,13 +9,12 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
-	"google.golang.org/grpc"
-
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	pb "github.com/grpc-ecosystem/go-grpc-prometheus/examples/grpc-server-with-prometheus/protobuf"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 )
 
 func main() {
@@ -28,8 +27,8 @@ func main() {
 	// Create a insecure gRPC channel to communicate with the server.
 	conn, err := grpc.Dial(
 		fmt.Sprintf("localhost:%v", 9093),
-		grpc.WithUnaryInterceptor(grpcMetrics.UnaryClientInterceptor()),
-		grpc.WithStreamInterceptor(grpcMetrics.StreamClientInterceptor()),
+		grpc.WithUnaryInterceptor(grpcMetrics.UnaryInterceptor()),
+		grpc.WithStreamInterceptor(grpcMetrics.StreamInterceptor()),
 		grpc.WithInsecure(),
 	)
 	if err != nil {

--- a/metric_options.go
+++ b/metric_options.go
@@ -4,19 +4,20 @@ import (
 	prom "github.com/prometheus/client_golang/prometheus"
 )
 
-type options struct {
+// CollectorOption lets you add options to monitor using With* funcs.
+type CollectorOption func(*collectorOptions)
+
+type collectorOptions struct {
 	namespace, subsystem string
 	constLabels          prom.Labels
 	buckets              []float64
 }
 
-// A CollectorOption lets you add options to monitor using With* funcs.
-type CollectorOption func(*options)
-
 type counterOptions []CollectorOption
 
+// TODO: remove once ServerMetrics is changed.
 func (co counterOptions) apply(base prom.Opts) prom.Opts {
-	var opts options
+	var opts collectorOptions
 	for _, f := range co {
 		f(&opts)
 	}
@@ -34,28 +35,28 @@ func (co counterOptions) apply(base prom.Opts) prom.Opts {
 
 // WithConstLabels allows you to add ConstLabels to Counter monitor.
 func WithConstLabels(labels prom.Labels) CollectorOption {
-	return func(o *options) {
+	return func(o *collectorOptions) {
 		o.constLabels = labels
 	}
 }
 
-// WithSubsystem allows to change default subsystem.
+// WithNamespace allows to change default subsystem.
 func WithNamespace(namespace string) CollectorOption {
-	return func(o *options) {
+	return func(o *collectorOptions) {
 		o.namespace = namespace
 	}
 }
 
 // WithSubsystem allows to change default subsystem.
 func WithSubsystem(subsystem string) CollectorOption {
-	return func(o *options) {
+	return func(o *collectorOptions) {
 		o.subsystem = subsystem
 	}
 }
 
 // WithBuckets allows you to specify custom bucket ranges for histograms.
 func WithBuckets(buckets []float64) CollectorOption {
-	return func(o *options) {
+	return func(o *collectorOptions) {
 		o.buckets = buckets
 	}
 }

--- a/monitor.go
+++ b/monitor.go
@@ -1,0 +1,240 @@
+package grpc_prometheus
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	namespace      = "grpc"
+	labelService   = "grpc_service"
+	labelMethod    = "grpc_method"
+	labelType      = "grpc_type"
+	labelCode      = "grpc_code"
+	labelUserAgent = "grpc_user_agent"
+	labelFailFast  = "grpc_fail_fast"
+)
+
+type monitor struct {
+	// Counters
+	requestsTotal    *prometheus.CounterVec
+	responsesTotal   *prometheus.CounterVec
+	messagesReceived *prometheus.CounterVec
+	messagesSent     *prometheus.CounterVec
+	errors           *prometheus.CounterVec
+	// Gauges
+	connections      *prometheus.GaugeVec
+	inFlightRequests *prometheus.GaugeVec
+	// Histograms
+	requestDuration *prometheus.HistogramVec
+}
+
+var _ prometheus.Collector = &monitor{}
+
+// Describe implements prometheus Collector interface.
+func (m *monitor) Describe(in chan<- *prometheus.Desc) {
+	// CounterVec
+	m.requestsTotal.Describe(in)
+	m.responsesTotal.Describe(in)
+	m.messagesSent.Describe(in)
+	m.messagesReceived.Describe(in)
+	m.errors.Describe(in)
+
+	// Gauge
+	m.connections.Describe(in)
+	m.inFlightRequests.Describe(in)
+
+	// HistogramVec
+	m.requestDuration.Describe(in)
+}
+
+// Collect implements prometheus Collector interface.
+func (m *monitor) Collect(in chan<- prometheus.Metric) {
+	// CounterVec
+	m.requestsTotal.Collect(in)
+	m.responsesTotal.Collect(in)
+	m.messagesSent.Collect(in)
+	m.messagesReceived.Collect(in)
+	m.errors.Collect(in)
+
+	// Gauge
+	m.connections.Collect(in)
+	m.inFlightRequests.Collect(in)
+
+	// HistogramVec
+	m.requestDuration.Collect(in)
+
+}
+
+type clientMonitor struct {
+	dialer *prometheus.CounterVec
+	*monitor
+}
+
+var _ prometheus.Collector = &clientMonitor{}
+
+func initClientMonitor(opts prometheus.Opts) *clientMonitor {
+	dialer := prometheus.NewCounterVec(
+		counterOpts(opts, "reconnects_total", "A total number of reconnects made by the client."),
+		[]string{"address"},
+	)
+
+	// Counters
+	requestsTotal := prometheus.NewCounterVec(
+		counterOpts(opts, "requests_total", "A total number of reconnects made by the client.."),
+		[]string{labelService, labelMethod, labelType},
+	)
+	responsesTotal := prometheus.NewCounterVec(
+		counterOpts(opts, "responses_total", "A total number of RPC responses received by the client."),
+		[]string{labelService, labelMethod, labelCode, labelType},
+	)
+	receivedMessages := prometheus.NewCounterVec(
+		counterOpts(opts, "received_messages_total", "A total number of RPC messages received by the client."),
+		[]string{labelService, labelMethod, labelType},
+	)
+	sentMessages := prometheus.NewCounterVec(
+		counterOpts(opts, "sent_messages_total", "A total number of RPC messages sent by the client."),
+		[]string{labelService, labelMethod, labelType},
+	)
+	errors := prometheus.NewCounterVec(
+		counterOpts(opts, "errors_total", "A total number of errors that happen during RPC calls."),
+		[]string{labelService, labelMethod, labelCode, labelType},
+	)
+
+	// Gauges
+	connections := prometheus.NewGaugeVec(
+		gaugeOpts(opts, "connections", "A current number of incoming RPC connections."),
+		[]string{"remote_addr", "local_addr"},
+	)
+	inFlightRequests := prometheus.NewGaugeVec(
+		gaugeOpts(opts, "in_flight_requests", "A number of currently processed client-side RPC requests."),
+		[]string{labelFailFast, labelMethod, labelService},
+	)
+
+	// Histograms
+	requestDuration := prometheus.NewHistogramVec(
+		histogramOpts(opts, "request_duration_histogram_seconds", "The RPC request latencies in seconds on the client side.", nil),
+		[]string{labelService, labelMethod, labelCode, labelType},
+	)
+
+	return &clientMonitor{
+		dialer: dialer,
+		monitor: &monitor{
+			connections:      connections,
+			inFlightRequests: inFlightRequests,
+			requestsTotal:    requestsTotal,
+			responsesTotal:   responsesTotal,
+			requestDuration:  requestDuration,
+			messagesReceived: receivedMessages,
+			messagesSent:     sentMessages,
+			errors:           errors,
+		},
+	}
+}
+
+// Describe implements prometheus Collector interface.
+func (cm *clientMonitor) Describe(in chan<- *prometheus.Desc) {
+	cm.dialer.Describe(in)
+	cm.monitor.Describe(in)
+}
+
+// Collect implements prometheus Collector interface.
+func (cm *clientMonitor) Collect(in chan<- prometheus.Metric) {
+	cm.dialer.Collect(in)
+	cm.monitor.Collect(in)
+}
+
+type serverMonitor struct {
+	*monitor
+}
+
+var _ prometheus.Collector = &clientMonitor{}
+
+func initServerMonitor(opts prometheus.Opts) *serverMonitor {
+	baseLabels := []string{labelService, labelMethod, labelUserAgent, labelType}
+
+	// Counters
+	requestsTotal := prometheus.NewCounterVec(
+		counterOpts(opts, "received_requests_total", "A total number of RPC requests received by the server."),
+		labelsWith(baseLabels),
+	)
+	responsesTotal := prometheus.NewCounterVec(
+		counterOpts(opts, "responses_total", "A total number of RPC responses sent back by the server."),
+		labelsWith(baseLabels, labelCode),
+	)
+	receivedMessages := prometheus.NewCounterVec(
+		counterOpts(opts, "received_messages_total", "A total number of RPC messages received by the server."),
+		baseLabels,
+	)
+	sentMessages := prometheus.NewCounterVec(
+		counterOpts(opts, "sent_messages_total", "A total number of RPC messages sent by the server."),
+		baseLabels,
+	)
+	errors := prometheus.NewCounterVec(
+		counterOpts(opts, "errors_total", "A total number of errors that happen during RPC calls on the server side."),
+		labelsWith(baseLabels, labelCode),
+	)
+
+	// Gauges
+	connections := prometheus.NewGaugeVec(
+		gaugeOpts(opts, "connections", "A current number of outgoing RPC connections."),
+		[]string{"remote_addr", "local_addr", labelUserAgent},
+	)
+	inFlightRequests := prometheus.NewGaugeVec(
+		gaugeOpts(opts, "in_flight_requests", "A number of currently processed server-side RPC requests."),
+		labelsWith(baseLabels, labelFailFast),
+	)
+
+	// Histograms
+	requestDuration := prometheus.NewHistogramVec(
+		histogramOpts(opts, "request_duration_histogram_seconds", "The RPC request latencies in seconds on the server side.", nil),
+		labelsWith(baseLabels, labelCode),
+	)
+
+	return &serverMonitor{
+		monitor: &monitor{
+			connections:      connections,
+			inFlightRequests: inFlightRequests,
+			requestsTotal:    requestsTotal,
+			responsesTotal:   responsesTotal,
+			requestDuration:  requestDuration,
+			messagesReceived: receivedMessages,
+			messagesSent:     sentMessages,
+			errors:           errors,
+		},
+	}
+}
+
+func histogramOpts(opts prometheus.Opts, name, help string, buckets []float64) prometheus.HistogramOpts {
+	opts.Name = name
+	opts.Help = help
+
+	return prometheus.HistogramOpts{
+		Subsystem:   opts.Subsystem,
+		Namespace:   opts.Namespace,
+		Name:        name,
+		Help:        opts.Help,
+		ConstLabels: opts.ConstLabels,
+		Buckets:     buckets,
+	}
+}
+
+func counterOpts(opts prometheus.Opts, name, help string) prometheus.CounterOpts {
+	opts.Name = name
+	opts.Help = help
+
+	return prometheus.CounterOpts(opts)
+}
+
+func gaugeOpts(opts prometheus.Opts, name, help string) prometheus.GaugeOpts {
+	opts.Name = name
+	opts.Help = help
+
+	return prometheus.GaugeOpts(opts)
+}
+
+func labelsWith(base []string, additional ...string) []string {
+	res := make([]string, len(base)+len(additional))
+	copy(res, base)
+
+	return append(res, additional...)
+}

--- a/monitor.go
+++ b/monitor.go
@@ -72,7 +72,7 @@ type clientMonitor struct {
 
 var _ prometheus.Collector = &clientMonitor{}
 
-func initClientMonitor(opts prometheus.Opts) *clientMonitor {
+func initClientMonitor(opts prometheus.Opts, buckets []float64) *clientMonitor {
 	dialer := prometheus.NewCounterVec(
 		counterOpts(opts, "reconnects_total", "A total number of reconnects made by the client."),
 		[]string{"address"},
@@ -112,7 +112,7 @@ func initClientMonitor(opts prometheus.Opts) *clientMonitor {
 
 	// Histograms
 	requestDuration := prometheus.NewHistogramVec(
-		histogramOpts(opts, "request_duration_histogram_seconds", "The RPC request latencies in seconds on the client side.", nil),
+		histogramOpts(opts, "request_duration_histogram_seconds", "The RPC request latencies in seconds on the client side.", buckets),
 		[]string{labelService, labelMethod, labelCode, labelType},
 	)
 

--- a/server.go
+++ b/server.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	// DefaultServerMetrics is the default instance of ServerMetrics. It is
-	// intended to be used in conjunction the default Prometheus metrics
+	// intended to be used in conjunction the default Prometheus monitor
 	// registry.
 	DefaultServerMetrics = NewServerMetrics()
 
@@ -31,18 +31,18 @@ func init() {
 }
 
 // Register takes a gRPC server and pre-initializes all counters to 0. This
-// allows for easier monitoring in Prometheus (no missing metrics), and should
+// allows for easier monitoring in Prometheus (no missing monitor), and should
 // be called *after* all services have been registered with the server. This
 // function acts on the DefaultServerMetrics variable.
 func Register(server *grpc.Server) {
 	DefaultServerMetrics.InitializeMetrics(server)
 }
 
-// EnableHandlingTimeHistogram turns on recording of handling time
-// of RPCs. Histogram metrics can be very expensive for Prometheus
-// to retain and query. This function acts on the DefaultServerMetrics
-// variable and the default Prometheus metrics registry.
-func EnableHandlingTimeHistogram(opts ...HistogramOption) {
-	DefaultServerMetrics.EnableHandlingTimeHistogram(opts...)
-	prom.Register(DefaultServerMetrics.serverHandledHistogram)
-}
+//// EnableHandlingTimeHistogram turns on recording of handling time
+//// of RPCs. Histogram monitor can be very expensive for Prometheus
+//// to retain and query. This function acts on the DefaultServerMetrics
+//// variable and the default Prometheus monitor registry.
+//func EnableHandlingTimeHistogram(opts ...HistogramCollectorOption) {
+//	DefaultServerMetrics.EnableHandlingTimeHistogram(opts...)
+//	prom.Register(DefaultServerMetrics.serverHandledHistogram)
+//}

--- a/server_metrics.go
+++ b/server_metrics.go
@@ -58,8 +58,8 @@ func NewServerMetrics(counterOpts ...CollectorOption) *ServerMetrics {
 
 //// EnableHandlingTimeHistogram enables histograms being registered when
 //// registering the ServerMetrics on a Prometheus registry. Histograms can be
-//// expensive on Prometheus servers. It takes options to configure histogram
-//// options such as the defined buckets.
+//// expensive on Prometheus servers. It takes collectorOptions to configure histogram
+//// collectorOptions such as the defined buckets.
 //func (m *ServerMetrics) EnableHandlingTimeHistogram(opts ...HistogramCollectorOption) {
 //	for _, o := range opts {
 //		o(&m.serverHandledHistogramOpts)

--- a/server_metrics.go
+++ b/server_metrics.go
@@ -7,8 +7,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// ServerMetrics represents a collection of metrics to be registered on a
-// Prometheus metrics registry for a gRPC server.
+// ServerMetrics represents a collection of monitor to be registered on a
+// Prometheus monitor registry for a gRPC server.
 type ServerMetrics struct {
 	serverStartedCounter          *prom.CounterVec
 	serverHandledCounter          *prom.CounterVec
@@ -20,60 +20,60 @@ type ServerMetrics struct {
 }
 
 // NewServerMetrics returns a ServerMetrics object. Use a new instance of
-// ServerMetrics when not using the default Prometheus metrics registry, for
-// example when wanting to control which metrics are added to a registry as
-// opposed to automatically adding metrics via init functions.
-func NewServerMetrics(counterOpts ...CounterOption) *ServerMetrics {
+// ServerMetrics when not using the default Prometheus monitor registry, for
+// example when wanting to control which monitor are added to a registry as
+// opposed to automatically adding monitor via init functions.
+func NewServerMetrics(counterOpts ...CollectorOption) *ServerMetrics {
 	opts := counterOptions(counterOpts)
 	return &ServerMetrics{
 		serverStartedCounter: prom.NewCounterVec(
-			opts.apply(prom.CounterOpts{
+			prom.CounterOpts(opts.apply(prom.Opts{
 				Name: "grpc_server_started_total",
 				Help: "Total number of RPCs started on the server.",
-			}), []string{"grpc_type", "grpc_service", "grpc_method"}),
+			})), []string{"grpc_type", "grpc_service", "grpc_method"}),
 		serverHandledCounter: prom.NewCounterVec(
-			opts.apply(prom.CounterOpts{
+			prom.CounterOpts(opts.apply(prom.Opts{
 				Name: "grpc_server_handled_total",
 				Help: "Total number of RPCs completed on the server, regardless of success or failure.",
-			}), []string{"grpc_type", "grpc_service", "grpc_method", "grpc_code"}),
+			})), []string{"grpc_type", "grpc_service", "grpc_method", "grpc_code"}),
 		serverStreamMsgReceived: prom.NewCounterVec(
-			opts.apply(prom.CounterOpts{
+			prom.CounterOpts(opts.apply(prom.Opts{
 				Name: "grpc_server_msg_received_total",
 				Help: "Total number of RPC stream messages received on the server.",
-			}), []string{"grpc_type", "grpc_service", "grpc_method"}),
+			})), []string{"grpc_type", "grpc_service", "grpc_method"}),
 		serverStreamMsgSent: prom.NewCounterVec(
-			opts.apply(prom.CounterOpts{
+			prom.CounterOpts(opts.apply(prom.Opts{
 				Name: "grpc_server_msg_sent_total",
 				Help: "Total number of gRPC stream messages sent by the server.",
-			}), []string{"grpc_type", "grpc_service", "grpc_method"}),
+			})), []string{"grpc_type", "grpc_service", "grpc_method"}),
 		serverHandledHistogramEnabled: false,
 		serverHandledHistogramOpts: prom.HistogramOpts{
 			Name:    "grpc_server_handling_seconds",
-			Help:    "Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.",
+			Help:    "Histogram of incomingResponse latency (seconds) of gRPC that had been application-level incomingResponse by the server.",
 			Buckets: prom.DefBuckets,
 		},
 		serverHandledHistogram: nil,
 	}
 }
 
-// EnableHandlingTimeHistogram enables histograms being registered when
-// registering the ServerMetrics on a Prometheus registry. Histograms can be
-// expensive on Prometheus servers. It takes options to configure histogram
-// options such as the defined buckets.
-func (m *ServerMetrics) EnableHandlingTimeHistogram(opts ...HistogramOption) {
-	for _, o := range opts {
-		o(&m.serverHandledHistogramOpts)
-	}
-	if !m.serverHandledHistogramEnabled {
-		m.serverHandledHistogram = prom.NewHistogramVec(
-			m.serverHandledHistogramOpts,
-			[]string{"grpc_type", "grpc_service", "grpc_method"},
-		)
-	}
-	m.serverHandledHistogramEnabled = true
-}
+//// EnableHandlingTimeHistogram enables histograms being registered when
+//// registering the ServerMetrics on a Prometheus registry. Histograms can be
+//// expensive on Prometheus servers. It takes options to configure histogram
+//// options such as the defined buckets.
+//func (m *ServerMetrics) EnableHandlingTimeHistogram(opts ...HistogramCollectorOption) {
+//	for _, o := range opts {
+//		o(&m.serverHandledHistogramOpts)
+//	}
+//	if !m.serverHandledHistogramEnabled {
+//		m.serverHandledHistogram = prom.NewHistogramVec(
+//			m.serverHandledHistogramOpts,
+//			[]string{"grpc_type", "grpc_service", "grpc_method"},
+//		)
+//	}
+//	m.serverHandledHistogramEnabled = true
+//}
 
-// Describe sends the super-set of all possible descriptors of metrics
+// Describe sends the super-set of all possible descriptors of monitor
 // collected by this Collector to the provided channel and returns once
 // the last descriptor has been sent.
 func (m *ServerMetrics) Describe(ch chan<- *prom.Desc) {
@@ -87,7 +87,7 @@ func (m *ServerMetrics) Describe(ch chan<- *prom.Desc) {
 }
 
 // Collect is called by the Prometheus registry when collecting
-// metrics. The implementation sends each collected metric via the
+// monitor. The implementation sends each collected metric via the
 // provided channel and returns once the last metric has been sent.
 func (m *ServerMetrics) Collect(ch chan<- prom.Metric) {
 	m.serverStartedCounter.Collect(ch)
@@ -125,9 +125,9 @@ func (m *ServerMetrics) StreamServerInterceptor() func(srv interface{}, ss grpc.
 	}
 }
 
-// InitializeMetrics initializes all metrics, with their appropriate null
+// InitializeMetrics initializes all monitor, with their appropriate null
 // value, for all gRPC methods registered on a gRPC server. This is useful, to
-// ensure that all metrics exist when collecting and querying.
+// ensure that all monitor exist when collecting and querying.
 func (m *ServerMetrics) InitializeMetrics(server *grpc.Server) {
 	serviceInfo := server.GetServiceInfo()
 	for serviceName, info := range serviceInfo {


### PR DESCRIPTION
This PR is related to #60, it introduces:

* No global state (client metrics).
* Shared `monitor` struct.
* Changed metric names to be more consistent and intuitive. **_breaking_**
    * counters
        * `started_total` -> `requests_total`
        * `handled_total` -> `responses_total`
        * `msg_received_total` -> `received_messages_total`
        * `msg_sent_total` -> `sent_messages_total`
    * gauges (**new**)
        * `in_flight_requests` // partially
        * `connections` // partially
    * histograms
        * `handling_seconds`->`request_duration_histogram_seconds`
* Request duration metric (histogram) is not optional anymore. **_breaking_** 
* `clientReporter` API become private
* `CounterOption` and `HistogramOption` replaced by `CollectorOption` **_breaking_**
    * `WithConstLabels`
    * `WithNamespace`
    * `WithSubsystem`
    * `WithBuckets`

**TODO:**
[ ] if accepted, apply similar changes to `ServerMetrics`