### PR TITLE
tests: Fixed known unit-test race conditions causing CI to be flaky.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -13,7 +13,6 @@ import (
 
 	pb_testproto "github.com/grpc-ecosystem/go-grpc-prometheus/examples/testproto"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/context"
@@ -71,6 +70,13 @@ func (s *ClientInterceptorTestSuite) SetupSuite() {
 func (s *ClientInterceptorTestSuite) SetupTest() {
 	// Make all RPC calls last at most 2 sec, meaning all async issues or deadlock will not kill tests.
 	s.ctx, _ = context.WithTimeout(context.TODO(), 2*time.Second)
+
+	// Make sure every test starts with same fresh, intialized metric state.
+	DefaultClientMetrics.clientStartedCounter.Reset()
+	DefaultClientMetrics.clientHandledCounter.Reset()
+	DefaultClientMetrics.clientHandledHistogram.Reset()
+	DefaultClientMetrics.clientStreamMsgReceived.Reset()
+	DefaultClientMetrics.clientStreamMsgSent.Reset()
 }
 
 func (s *ClientInterceptorTestSuite) TearDownSuite() {
@@ -85,122 +91,31 @@ func (s *ClientInterceptorTestSuite) TearDownSuite() {
 	}
 }
 
-func (s *ClientInterceptorTestSuite) TestUnaryIncrementsStarted() {
-	var before int
-	var after int
+func (s *ClientInterceptorTestSuite) TestUnaryIncrementsMetrics() {
+	_, err := s.testClient.PingEmpty(s.ctx, &pb_testproto.Empty{}) // should return with code=OK
+	require.NoError(s.T(), err)
+	requireValue(s.T(), 1, DefaultClientMetrics.clientStartedCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingEmpty"))
+	requireValue(s.T(), 1, DefaultClientMetrics.clientHandledCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingEmpty", "OK"))
+	requireValueHistCount(s.T(), 1, DefaultClientMetrics.clientHandledHistogram.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingEmpty"))
 
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_started_total", "PingEmpty", "unary")
-	s.testClient.PingEmpty(s.ctx, &pb_testproto.Empty{})
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_started_total", "PingEmpty", "unary")
-	assert.EqualValues(s.T(), before+1, after, "grpc_client_started_total should be incremented for PingEmpty")
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_started_total", "PingError", "unary")
-	s.testClient.PingError(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.Unavailable)})
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_started_total", "PingError", "unary")
-	assert.EqualValues(s.T(), before+1, after, "grpc_client_started_total should be incremented for PingError")
+	_, err = s.testClient.PingError(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
+	require.Error(s.T(), err)
+	requireValue(s.T(), 1, DefaultClientMetrics.clientStartedCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingError"))
+	requireValue(s.T(), 1, DefaultClientMetrics.clientHandledCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingError", "FailedPrecondition"))
+	requireValueHistCount(s.T(), 1, DefaultClientMetrics.clientHandledHistogram.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingError"))
 }
 
-func (s *ClientInterceptorTestSuite) TestUnaryIncrementsHandled() {
-	var before int
-	var after int
+func (s *ClientInterceptorTestSuite) TestStartedStreamingIncrementsStarted() {
+	_, err := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{})
+	require.NoError(s.T(), err)
+	requireValue(s.T(), 1, DefaultClientMetrics.clientStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
 
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingEmpty", "unary", "OK")
-	s.testClient.PingEmpty(s.ctx, &pb_testproto.Empty{}) // should return with code=OK
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingEmpty", "unary", "OK")
-	assert.EqualValues(s.T(), before+1, after, "grpc_client_handled_count should be incremented for PingEmpty")
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingError", "unary", "FailedPrecondition")
-	s.testClient.PingError(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingError", "unary", "FailedPrecondition")
-	assert.EqualValues(s.T(), before+1, after, "grpc_client_handled_total should be incremented for PingError")
-}
-
-func (s *ClientInterceptorTestSuite) TestUnaryIncrementsHistograms() {
-	var before int
-	var after int
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingEmpty", "unary")
-	s.testClient.PingEmpty(s.ctx, &pb_testproto.Empty{}) // should return with code=OK
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingEmpty", "unary")
-	assert.EqualValues(s.T(), before+1, after, "grpc_client_handled_count should be incremented for PingEmpty")
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingError", "unary")
-	s.testClient.PingError(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingError", "unary")
-	assert.EqualValues(s.T(), before+1, after, "grpc_client_handling_seconds_count should be incremented for PingError")
-}
-
-func (s *ClientInterceptorTestSuite) TestStreamingIncrementsStarted() {
-	var before int
-	var after int
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_started_total", "PingList", "server_stream")
-	s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{})
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_started_total", "PingList", "server_stream")
-	assert.EqualValues(s.T(), before+1, after, "grpc_client_started_total should be incremented for PingList")
-}
-
-func (s *ClientInterceptorTestSuite) TestStreamingIncrementsHistograms() {
-	var before int
-	var after int
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingList", "server_stream")
-	ss, _ := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{}) // should return with code=OK
-	// Do a read, just for kicks.
-	for {
-		_, err := ss.Recv()
-		if err == io.EOF {
-			break
-		}
-		require.NoError(s.T(), err, "reading pingList shouldn't fail")
-	}
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingList", "server_stream")
-	assert.EqualValues(s.T(), before+1, after, "grpc_client_handling_seconds_count should be incremented for PingList OK")
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingList", "server_stream")
-	ss, err := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
+	_, err = s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
 	require.NoError(s.T(), err, "PingList must not fail immediately")
-	// Do a read, just to progate errors.
-	_, err = ss.Recv()
-	st, _ := status.FromError(err)
-	require.Equal(s.T(), codes.FailedPrecondition, st.Code(), "Recv must return FailedPrecondition, otherwise the test is wrong")
-
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handling_seconds_count", "PingList", "server_stream")
-	assert.EqualValues(s.T(), before+1, after, "grpc_client_handling_seconds_count should be incremented for PingList FailedPrecondition")
+	requireValue(s.T(), 2, DefaultClientMetrics.clientStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
 }
 
-func (s *ClientInterceptorTestSuite) TestStreamingIncrementsHandled() {
-	var before int
-	var after int
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingList", "server_stream", "OK")
-	ss, _ := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{}) // should return with code=OK
-	// Do a read, just for kicks.
-	for {
-		_, err := ss.Recv()
-		if err == io.EOF {
-			break
-		}
-		require.NoError(s.T(), err, "reading pingList shouldn't fail")
-	}
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingList", "server_stream", "OK")
-	assert.EqualValues(s.T(), before+1, after, "grpc_client_handled_total should be incremented for PingList OK")
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingList", "server_stream", "FailedPrecondition")
-	ss, err := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
-	require.NoError(s.T(), err, "PingList must not fail immediately")
-	// Do a read, just to progate errors.
-	_, err = ss.Recv()
-	st, _ := status.FromError(err)
-	require.Equal(s.T(), codes.FailedPrecondition, st.Code(), "Recv must return FailedPrecondition, otherwise the test is wrong")
-
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_client_handled_total", "PingList", "server_stream", "FailedPrecondition")
-	assert.EqualValues(s.T(), before+1, after, "grpc_client_handled_total should be incremented for PingList FailedPrecondition")
-}
-
-func (s *ClientInterceptorTestSuite) TestStreamingIncrementsMessageCounts() {
-	beforeRecv := sumCountersForMetricAndLabels(s.T(), "grpc_client_msg_received_total", "PingList", "server_stream")
-	beforeSent := sumCountersForMetricAndLabels(s.T(), "grpc_client_msg_sent_total", "PingList", "server_stream")
+func (s *ClientInterceptorTestSuite) TestStreamingIncrementsMetrics() {
 	ss, _ := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{}) // should return with code=OK
 	// Do a read, just for kicks.
 	count := 0
@@ -213,9 +128,22 @@ func (s *ClientInterceptorTestSuite) TestStreamingIncrementsMessageCounts() {
 		count++
 	}
 	require.EqualValues(s.T(), countListResponses, count, "Number of received msg on the wire must match")
-	afterSent := sumCountersForMetricAndLabels(s.T(), "grpc_client_msg_sent_total", "PingList", "server_stream")
-	afterRecv := sumCountersForMetricAndLabels(s.T(), "grpc_client_msg_received_total", "PingList", "server_stream")
 
-	assert.EqualValues(s.T(), beforeSent+1, afterSent, "grpc_client_msg_sent_total should be incremented 20 times for PingList")
-	assert.EqualValues(s.T(), beforeRecv+countListResponses, afterRecv, "grpc_client_msg_sent_total should be incremented ones for PingList ")
+	requireValue(s.T(), 1, DefaultClientMetrics.clientStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+	requireValue(s.T(), 1, DefaultClientMetrics.clientHandledCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList", "OK"))
+	requireValue(s.T(), countListResponses, DefaultClientMetrics.clientStreamMsgReceived.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+	requireValue(s.T(), 1, DefaultClientMetrics.clientStreamMsgSent.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+	requireValueHistCount(s.T(), 1, DefaultClientMetrics.clientHandledHistogram.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+
+	ss, err := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
+	require.NoError(s.T(), err, "PingList must not fail immediately")
+
+	// Do a read, just to progate errors.
+	_, err = ss.Recv()
+	st, _ := status.FromError(err)
+	require.Equal(s.T(), codes.FailedPrecondition, st.Code(), "Recv must return FailedPrecondition, otherwise the test is wrong")
+
+	requireValue(s.T(), 2, DefaultClientMetrics.clientStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+	requireValue(s.T(), 1, DefaultClientMetrics.clientHandledCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList", "FailedPrecondition"))
+	requireValueHistCount(s.T(), 2, DefaultClientMetrics.clientHandledHistogram.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
 }

--- a/server_test.go
+++ b/server_test.go
@@ -5,17 +5,22 @@ package grpc_prometheus
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
 	pb_testproto "github.com/grpc-ecosystem/go-grpc-prometheus/examples/testproto"
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -71,14 +76,19 @@ func (s *ServerInterceptorTestSuite) SetupSuite() {
 	s.clientConn, err = grpc.Dial(s.serverListener.Addr().String(), grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(2*time.Second))
 	require.NoError(s.T(), err, "must not error on client Dial")
 	s.testClient = pb_testproto.NewTestServiceClient(s.clientConn)
-
-	// Important! Pre-register stuff here.
-	Register(s.server)
 }
 
 func (s *ServerInterceptorTestSuite) SetupTest() {
 	// Make all RPC calls last at most 2 sec, meaning all async issues or deadlock will not kill tests.
 	s.ctx, _ = context.WithTimeout(context.TODO(), 2*time.Second)
+
+	// Make sure every test starts with same fresh, intialized metric state.
+	DefaultServerMetrics.serverStartedCounter.Reset()
+	DefaultServerMetrics.serverHandledCounter.Reset()
+	DefaultServerMetrics.serverHandledHistogram.Reset()
+	DefaultServerMetrics.serverStreamMsgReceived.Reset()
+	DefaultServerMetrics.serverStreamMsgSent.Reset()
+	Register(s.server)
 }
 
 func (s *ServerInterceptorTestSuite) TearDownSuite() {
@@ -98,6 +108,7 @@ func (s *ServerInterceptorTestSuite) TestRegisterPresetsStuff() {
 		metricName     string
 		existingLabels []string
 	}{
+		// Order of label is irrelevant.
 		{"grpc_server_started_total", []string{"mwitkow.testproto.TestService", "PingEmpty", "unary"}},
 		{"grpc_server_started_total", []string{"mwitkow.testproto.TestService", "PingList", "server_stream"}},
 		{"grpc_server_msg_received_total", []string{"mwitkow.testproto.TestService", "PingList", "server_stream"}},
@@ -114,114 +125,33 @@ func (s *ServerInterceptorTestSuite) TestRegisterPresetsStuff() {
 	}
 }
 
-func (s *ServerInterceptorTestSuite) TestUnaryIncrementsStarted() {
-	var before int
-	var after int
+func (s *ServerInterceptorTestSuite) TestUnaryIncrementsMetrics() {
+	_, err := s.testClient.PingEmpty(s.ctx, &pb_testproto.Empty{}) // should return with code=OK
+	require.NoError(s.T(), err)
+	requireValue(s.T(), 1, DefaultServerMetrics.serverStartedCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingEmpty"))
+	requireValue(s.T(), 1, DefaultServerMetrics.serverHandledCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingEmpty", "OK"))
+	requireValueHistCount(s.T(), 1, DefaultServerMetrics.serverHandledHistogram.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingEmpty"))
 
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_server_started_total", "PingEmpty", "unary")
-	s.testClient.PingEmpty(s.ctx, &pb_testproto.Empty{})
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_server_started_total", "PingEmpty", "unary")
-	assert.EqualValues(s.T(), before+1, after, "grpc_server_started_total should be incremented for PingEmpty")
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_server_started_total", "PingError", "unary")
-	s.testClient.PingError(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.Unavailable)})
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_server_started_total", "PingError", "unary")
-	assert.EqualValues(s.T(), before+1, after, "grpc_server_started_total should be incremented for PingError")
+	_, err = s.testClient.PingError(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
+	require.Error(s.T(), err)
+	requireValue(s.T(), 1, DefaultServerMetrics.serverStartedCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingError"))
+	requireValue(s.T(), 1, DefaultServerMetrics.serverHandledCounter.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingError", "FailedPrecondition"))
+	requireValueHistCount(s.T(), 1, DefaultServerMetrics.serverHandledHistogram.WithLabelValues("unary", "mwitkow.testproto.TestService", "PingError"))
 }
 
-func (s *ServerInterceptorTestSuite) TestUnaryIncrementsHandled() {
-	var before int
-	var after int
+func (s *ServerInterceptorTestSuite) TestStartedStreamingIncrementsStarted() {
+	_, err := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{})
+	require.NoError(s.T(), err)
+	requireValueWithRetry(s.ctx, s.T(), 1,
+		DefaultServerMetrics.serverStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
 
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_server_handled_total", "PingEmpty", "unary", "OK")
-	s.testClient.PingEmpty(s.ctx, &pb_testproto.Empty{}) // should return with code=OK
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_server_handled_total", "PingEmpty", "unary", "OK")
-	assert.EqualValues(s.T(), before+1, after, "grpc_server_handled_count should be incremented for PingEmpty")
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_server_handled_total", "PingError", "unary", "FailedPrecondition")
-	s.testClient.PingError(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_server_handled_total", "PingError", "unary", "FailedPrecondition")
-	assert.EqualValues(s.T(), before+1, after, "grpc_server_handled_total should be incremented for PingError")
-}
-
-func (s *ServerInterceptorTestSuite) TestUnaryIncrementsHistograms() {
-	var before int
-	var after int
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_server_handling_seconds_count", "PingEmpty", "unary")
-	s.testClient.PingEmpty(s.ctx, &pb_testproto.Empty{}) // should return with code=OK
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_server_handling_seconds_count", "PingEmpty", "unary")
-	assert.EqualValues(s.T(), before+1, after, "grpc_server_handled_count should be incremented for PingEmpty")
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_server_handling_seconds_count", "PingError", "unary")
-	s.testClient.PingError(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_server_handling_seconds_count", "PingError", "unary")
-	assert.EqualValues(s.T(), before+1, after, "grpc_server_handling_seconds_count should be incremented for PingError")
-}
-
-func (s *ServerInterceptorTestSuite) TestStreamingIncrementsStarted() {
-	var before int
-	var after int
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_server_started_total", "PingList", "server_stream")
-	s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{})
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_server_started_total", "PingList", "server_stream")
-	assert.EqualValues(s.T(), before+1, after, "grpc_server_started_total should be incremented for PingList")
-}
-
-func (s *ServerInterceptorTestSuite) TestStreamingIncrementsHistograms() {
-	var before int
-	var after int
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_server_handling_seconds_count", "PingList", "server_stream")
-	ss, _ := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{}) // should return with code=OK
-	// Do a read, just for kicks.
-	for {
-		_, err := ss.Recv()
-		if err == io.EOF {
-			break
-		}
-		require.NoError(s.T(), err, "reading pingList shouldn't fail")
-	}
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_server_handling_seconds_count", "PingList", "server_stream")
-	assert.EqualValues(s.T(), before+1, after, "grpc_server_handling_seconds_count should be incremented for PingList OK")
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_server_handling_seconds_count", "PingList", "server_stream")
-	_, err := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
+	_, err = s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
 	require.NoError(s.T(), err, "PingList must not fail immediately")
-
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_server_handling_seconds_count", "PingList", "server_stream")
-	assert.EqualValues(s.T(), before+1, after, "grpc_server_handling_seconds_count should be incremented for PingList FailedPrecondition")
+	requireValueWithRetry(s.ctx, s.T(), 2,
+		DefaultServerMetrics.serverStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
 }
 
-func (s *ServerInterceptorTestSuite) TestStreamingIncrementsHandled() {
-	var before int
-	var after int
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_server_handled_total", "PingList", "server_stream", "OK")
-	ss, _ := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{}) // should return with code=OK
-	// Do a read, just for kicks.
-	for {
-		_, err := ss.Recv()
-		if err == io.EOF {
-			break
-		}
-		require.NoError(s.T(), err, "reading pingList shouldn't fail")
-	}
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_server_handled_total", "PingList", "server_stream", "OK")
-	assert.EqualValues(s.T(), before+1, after, "grpc_server_handled_total should be incremented for PingList OK")
-
-	before = sumCountersForMetricAndLabels(s.T(), "grpc_server_handled_total", "PingList", "server_stream", "FailedPrecondition")
-	_, err := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
-	require.NoError(s.T(), err, "PingList must not fail immediately")
-
-	after = sumCountersForMetricAndLabels(s.T(), "grpc_server_handled_total", "PingList", "server_stream", "FailedPrecondition")
-	assert.EqualValues(s.T(), before+1, after, "grpc_server_handled_total should be incremented for PingList FailedPrecondition")
-}
-
-func (s *ServerInterceptorTestSuite) TestStreamingIncrementsMessageCounts() {
-	beforeRecv := sumCountersForMetricAndLabels(s.T(), "grpc_server_msg_received_total", "PingList", "server_stream")
-	beforeSent := sumCountersForMetricAndLabels(s.T(), "grpc_server_msg_sent_total", "PingList", "server_stream")
+func (s *ServerInterceptorTestSuite) TestStreamingIncrementsMetrics() {
 	ss, _ := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{}) // should return with code=OK
 	// Do a read, just for kicks.
 	count := 0
@@ -234,20 +164,41 @@ func (s *ServerInterceptorTestSuite) TestStreamingIncrementsMessageCounts() {
 		count++
 	}
 	require.EqualValues(s.T(), countListResponses, count, "Number of received msg on the wire must match")
-	afterSent := sumCountersForMetricAndLabels(s.T(), "grpc_server_msg_sent_total", "PingList", "server_stream")
-	afterRecv := sumCountersForMetricAndLabels(s.T(), "grpc_server_msg_received_total", "PingList", "server_stream")
 
-	assert.EqualValues(s.T(), beforeSent+countListResponses, afterSent, "grpc_server_msg_sent_total should be incremented 20 times for PingList")
-	assert.EqualValues(s.T(), beforeRecv+1, afterRecv, "grpc_server_msg_sent_total should be incremented ones for PingList ")
+	requireValueWithRetry(s.ctx, s.T(), 1,
+		DefaultServerMetrics.serverStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+	requireValueWithRetry(s.ctx, s.T(), 1,
+		DefaultServerMetrics.serverHandledCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList", "OK"))
+	requireValueWithRetry(s.ctx, s.T(), countListResponses,
+		DefaultServerMetrics.serverStreamMsgSent.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+	requireValueWithRetry(s.ctx, s.T(), 1,
+		DefaultServerMetrics.serverStreamMsgReceived.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+	requireValueWithRetryHistCount(s.ctx, s.T(), 1,
+		DefaultServerMetrics.serverHandledHistogram.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+
+	_, err := s.testClient.PingList(s.ctx, &pb_testproto.PingRequest{ErrorCodeReturned: uint32(codes.FailedPrecondition)}) // should return with code=FailedPrecondition
+	require.NoError(s.T(), err, "PingList must not fail immediately")
+
+	requireValueWithRetry(s.ctx, s.T(), 2,
+		DefaultServerMetrics.serverStartedCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
+	requireValueWithRetry(s.ctx, s.T(), 1,
+		DefaultServerMetrics.serverHandledCounter.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList", "FailedPrecondition"))
+	requireValueWithRetryHistCount(s.ctx, s.T(), 2,
+		DefaultServerMetrics.serverHandledHistogram.WithLabelValues("server_stream", "mwitkow.testproto.TestService", "PingList"))
 }
 
+// fetchPrometheusLines does mocked HTTP GET request against real prometheus handler to get the same view that Prometheus
+// would have while scraping this endpoint.
+// Order of matching label vales does not matter.
 func fetchPrometheusLines(t *testing.T, metricName string, matchingLabelValues ...string) []string {
 	resp := httptest.NewRecorder()
 	req, err := http.NewRequest("GET", "/", nil)
 	require.NoError(t, err, "failed creating request for Prometheus handler")
-	prometheus.Handler().ServeHTTP(resp, req)
+
+	promhttp.Handler().ServeHTTP(resp, req)
 	reader := bufio.NewReader(resp.Body)
-	ret := []string{}
+
+	var ret []string
 	for {
 		line, err := reader.ReadString('\n')
 		if err == io.EOF {
@@ -270,17 +221,6 @@ func fetchPrometheusLines(t *testing.T, metricName string, matchingLabelValues .
 
 	}
 	return ret
-}
-
-func sumCountersForMetricAndLabels(t *testing.T, metricName string, matchingLabelValues ...string) int {
-	count := 0
-	for _, line := range fetchPrometheusLines(t, metricName, matchingLabelValues...) {
-		valueString := line[strings.LastIndex(line, " ")+1 : len(line)-1]
-		valueFloat, err := strconv.ParseFloat(valueString, 32)
-		require.NoError(t, err, "failed parsing value for line: %v", line)
-		count += int(valueFloat)
-	}
-	return count
 }
 
 type testService struct {
@@ -310,4 +250,100 @@ func (s *testService) PingList(ping *pb_testproto.PingRequest, stream pb_testpro
 		stream.Send(&pb_testproto.PingResponse{Value: ping.Value, Counter: int32(i)})
 	}
 	return nil
+}
+
+// toFloat64HistCount does the same thing as prometheus go client testutil.ToFloat64, but for histograms.
+// TODO(bwplotka): Upstream this function to prometheus client.
+func toFloat64HistCount(h prometheus.Observer) uint64 {
+	var (
+		m      prometheus.Metric
+		mCount int
+		mChan  = make(chan prometheus.Metric)
+		done   = make(chan struct{})
+	)
+
+	go func() {
+		for m = range mChan {
+			mCount++
+		}
+		close(done)
+	}()
+
+	c, ok := h.(prometheus.Collector)
+	if !ok {
+		panic(fmt.Errorf("observer is not a collector; got: %T", h))
+	}
+
+	c.Collect(mChan)
+	close(mChan)
+	<-done
+
+	if mCount != 1 {
+		panic(fmt.Errorf("collected %d metrics instead of exactly 1", mCount))
+	}
+
+	pb := &dto.Metric{}
+	m.Write(pb)
+	if pb.Histogram != nil {
+		return pb.Histogram.GetSampleCount()
+	}
+	panic(fmt.Errorf("collected a non-histogram metric: %s", pb))
+}
+
+func requireValue(t *testing.T, expect int, c prometheus.Collector) {
+	v := int(testutil.ToFloat64(c))
+	if v == expect {
+		return
+	}
+
+	metricFullName := reflect.ValueOf(*c.(prometheus.Metric).Desc()).FieldByName("fqName").String()
+	t.Errorf("expected %d %s value; got %d; ", expect, metricFullName, v)
+	t.Fail()
+}
+
+func requireValueHistCount(t *testing.T, expect int, o prometheus.Observer) {
+	v := int(toFloat64HistCount(o))
+	if v == expect {
+		return
+	}
+
+	metricFullName := reflect.ValueOf(*o.(prometheus.Metric).Desc()).FieldByName("fqName").String()
+	t.Errorf("expected %d %s value; got %d; ", expect, metricFullName, v)
+	t.Fail()
+}
+
+func requireValueWithRetry(ctx context.Context, t *testing.T, expect int, c prometheus.Collector) {
+	for {
+		v := int(testutil.ToFloat64(c))
+		if v == expect {
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			metricFullName := reflect.ValueOf(*c.(prometheus.Metric).Desc()).FieldByName("fqName").String()
+			t.Errorf("timeout while expecting %d %s value; got %d; ", expect, metricFullName, v)
+			t.Fail()
+			return
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+func requireValueWithRetryHistCount(ctx context.Context, t *testing.T, expect int, o prometheus.Observer) {
+	for {
+		v := int(toFloat64HistCount(o))
+		if v == expect {
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			metricFullName := reflect.ValueOf(*o.(prometheus.Metric).Desc()).FieldByName("fqName").String()
+			t.Errorf("timeout while expecting %d %s histogram count value; got %d; ", expect, metricFullName, v)
+			t.Fail()
+			return
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/grpc-ecosystem/go-grpc-prometheus/issues/56

Root cause of flakiness:
There was a race between checking metrics value rightafter doing srv streaming call
and server incrementing the actual metric.

Additionally, simplified tests to significantly decrease change amplification and cognitive load.

Signed-off-by: Bartek Plotka <bwplotka@gmail.com>