### PR TITLE
Do not unwrap errors by causer interface

### DIFF
--- a/packages/grpcstatus/grpcstatus.go
+++ b/packages/grpcstatus/grpcstatus.go
@@ -5,34 +5,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-type gRPCStatus interface {
-	GRPCStatus() *status.Status
-}
-
-func unwrapPkgErrorsGRPCStatus(err error) (*status.Status, bool) {
-	type causer interface {
-		Cause() error
-	}
-
-	// Unwrapping the github.com/pkg/errors causer interface, using `Cause` directly could miss some error implementing
-	// the `GRPCStatus` function so we have to check it on our selves.
-	unwrappedCauser := err
-	for unwrappedCauser != nil {
-		if s, ok := unwrappedCauser.(gRPCStatus); ok {
-			return s.GRPCStatus(), true
-		}
-		cause, ok := unwrappedCauser.(causer)
-		if !ok {
-			break
-		}
-		unwrappedCauser = cause.Cause()
-	}
-	return nil, false
-}
-
 // Since error can be wrapped and the `FromError` function only checks for `GRPCStatus` function
 // and as a fallback uses the `Unknown` gRPC status we need to unwrap the error if possible to get the original status.
-// pkg/errors and Go native errors packages have two different approaches so we try to unwrap both types.
 // Eventually should be implemented in the go-grpc status function `FromError`. See https://github.com/grpc/grpc-go/issues/2934
 func FromError(err error) (s *status.Status, ok bool) {
 	s, ok = status.FromError(err)
@@ -40,14 +14,8 @@ func FromError(err error) (s *status.Status, ok bool) {
 		return s, true
 	}
 
-	// Try to unwrap `github.com/pkg/errors` wrapped error
-	s, ok = unwrapPkgErrorsGRPCStatus(err)
-	if ok {
-		return s, true
-	}
-
-	// Try to unwrap native wrapped errors using `fmt.Errorf` and `%w`
-	s, ok = unwrapNativeWrappedGRPCStatus(err)
+	// Try to unwrap gRPC status
+	s, ok = unwrapGRPCStatus(err)
 	if ok {
 		return s, true
 	}

--- a/packages/grpcstatus/grpcstatus1.13+_test.go
+++ b/packages/grpcstatus/grpcstatus1.13+_test.go
@@ -4,16 +4,17 @@ package grpcstatus
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"testing"
 )
 
 func TestNativeErrorUnwrapping(t *testing.T) {
 	gRPCCode := codes.FailedPrecondition
 	gRPCError := status.Errorf(gRPCCode, "Userspace error.")
-	expectedGRPCStatus, _ := status.FromError(gRPCError)
+	expectedGRPCStatus := status.Convert(gRPCError)
 	testedErrors := []error{
 		fmt.Errorf("go native wrapped error: %w", gRPCError),
 	}

--- a/packages/grpcstatus/grpcstatus_test.go
+++ b/packages/grpcstatus/grpcstatus_test.go
@@ -1,10 +1,11 @@
 package grpcstatus
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"testing"
 )
 
 // Own implementation of pkg/errors withStack to avoid additional dependency
@@ -15,12 +16,12 @@ type wrappedError struct {
 
 func (w *wrappedError) Error() string { return w.msg + ": " + w.cause.Error() }
 
-func (w *wrappedError) Cause() error { return w.cause }
+func (w *wrappedError) Unwrap() error { return w.cause }
 
 func TestErrorUnwrapping(t *testing.T) {
 	gRPCCode := codes.FailedPrecondition
 	gRPCError := status.Errorf(gRPCCode, "Userspace error.")
-	expectedGRPCStatus, _ := status.FromError(gRPCError)
+	expectedGRPCStatus := status.Convert(gRPCError)
 	testedErrors := []error{
 		gRPCError,
 		&wrappedError{cause: gRPCError, msg: "pkg/errors wrapped error: "},

--- a/packages/grpcstatus/unwrap1.12-.go
+++ b/packages/grpcstatus/unwrap1.12-.go
@@ -6,6 +6,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func unwrapNativeWrappedGRPCStatus(err error) (*status.Status, bool) {
+func unwrapGRPCStatus(err error) (*status.Status, bool) {
 	return nil, false
 }

--- a/packages/grpcstatus/unwrap1.13+.go
+++ b/packages/grpcstatus/unwrap1.13+.go
@@ -4,10 +4,15 @@ package grpcstatus
 
 import (
 	"errors"
+
 	"google.golang.org/grpc/status"
 )
 
-func unwrapNativeWrappedGRPCStatus(err error) (*status.Status, bool) {
+type gRPCStatus interface {
+	GRPCStatus() *status.Status
+}
+
+func unwrapGRPCStatus(err error) (*status.Status, bool) {
 	// Unwrapping the native Go unwrap interface
 	var unwrappedStatus gRPCStatus
 	if ok := errors.As(err, &unwrappedStatus); ok {


### PR DESCRIPTION
github.com/pkg/errors [since version 0.9.0](https://github.com/pkg/errors/releases/tag/v0.9.0) [already supports](https://github.com/pkg/errors/blob/master/errors.go#L163) native error wrapping added in Go 1.13